### PR TITLE
Issue #5 - Suppport GPX 1.0

### DIFF
--- a/src/parser/bounds.rs
+++ b/src/parser/bounds.rs
@@ -1,0 +1,114 @@
+use errors::*;
+
+use std::iter::Peekable;
+use std::io::Read;
+use xml::reader::Events;
+use xml::reader::XmlEvent;
+use geo::Bbox;
+
+/// consume consumes an element as a nothing.
+pub fn consume<R: Read>(reader: &mut Peekable<Events<R>>) -> Result<Bbox<f64>> {
+    let mut element: Option<String> = None;
+    let mut bounds: Bbox<f64> = Bbox {
+        xmin: 0.,
+        xmax: 0.,
+        ymin: 0.,
+        ymax: 0.,
+    };
+    for event in reader {
+        match event.chain_err(|| "error while parsing XML")? {
+            XmlEvent::StartElement {
+                name, attributes, ..
+            } => {
+                ensure!(element.is_none(), "cannot start element inside bounds");
+                // get required bounds
+                let minlat = attributes
+                    .iter()
+                    .filter(|attr| attr.name.local_name == "minlat")
+                    .nth(0)
+                    .ok_or("no min latitude attribute on bounds tag".to_owned())?;
+                let maxlat = attributes
+                    .iter()
+                    .filter(|attr| attr.name.local_name == "maxlat")
+                    .nth(0)
+                    .ok_or("no max latitude attribute on bounds tag".to_owned())?;
+
+                let minlat: f64 = minlat
+                    .value
+                    .parse()
+                    .chain_err(|| "error while casting min latitude to f64")?;
+                let maxlat: f64 = maxlat
+                    .value
+                    .parse()
+                    .chain_err(|| "error while casting max latitude to f64")?;
+
+                let minlon = attributes
+                    .iter()
+                    .filter(|attr| attr.name.local_name == "minlon")
+                    .nth(0)
+                    .ok_or("no min longitude attribute on bounds tag".to_owned())?;
+                let maxlon = attributes
+                    .iter()
+                    .filter(|attr| attr.name.local_name == "maxlon")
+                    .nth(0)
+                    .ok_or("no max longitude attribute on bounds tag".to_owned())?;
+
+                let minlon: f64 = minlon
+                    .value
+                    .parse()
+                    .chain_err(|| "error while casting min longitude to f64")?;
+                let maxlon: f64 = maxlon
+                    .value
+                    .parse()
+                    .chain_err(|| "error while casting max longitude to f64")?;
+
+                bounds.xmin = minlon;
+                bounds.xmax = maxlon;
+                bounds.ymin = minlat;
+                bounds.ymax = maxlat;
+
+                element = Some(name.local_name);
+            }
+
+            XmlEvent::EndElement { .. } => {
+                return Ok(bounds);
+            }
+
+            _ => {}
+        }
+    }
+
+    return Err("no end tag for bounds".into());
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::BufReader;
+    use xml::reader::EventReader;
+
+    use super::consume;
+
+    #[test]
+    fn consume_bounds() {
+        let bounds = consume!(
+            "
+<bounds minlat=\"45.487064362\" minlon=\"-74.031837463\" maxlat=\"45.701225281\" maxlon=\"-73.586273193\"/>
+            "
+        );
+
+        assert!(bounds.is_ok());
+
+        let bounds = bounds.unwrap();
+        assert_eq!(bounds.xmin, -74.031837463);
+        assert_eq!(bounds.ymin, 45.487064362);
+        assert_eq!(bounds.xmax, -73.586273193);
+        assert_eq!(bounds.ymax, 45.701225281);
+    }
+
+    #[test]
+    fn consume_bad_bounds() {
+        let bounds = consume!("<bounds minlat=\"32.4\" minlon=\"notanumber\"></wpt>");
+
+        assert!(bounds.is_err());
+    }
+}

--- a/src/parser/extensions.rs
+++ b/src/parser/extensions.rs
@@ -3,16 +3,16 @@
 // TODO: extensions are not implemented
 
 use errors::*;
-use std::iter::Peekable;
 use std::io::Read;
-use xml::reader::Events;
 use xml::reader::XmlEvent;
 
+use parser::Context;
+
 /// consume consumes a single string as tag content.
-pub fn consume<R: Read>(reader: &mut Peekable<Events<R>>) -> Result<()> {
+pub fn consume<R: Read>(context: &mut Context<R>) -> Result<()> {
     let mut started = false;
 
-    for event in reader {
+    for event in context.reader() {
         match event.chain_err(|| "error while parsing XML")? {
             XmlEvent::StartElement { name, .. } => {
                 // flip started depending on conditions
@@ -41,6 +41,8 @@ mod tests {
     use std::io::BufReader;
     use xml::reader::EventReader;
 
+    use GpxVersion;
+    use parser::Context;
     use super::consume;
 
     #[test]
@@ -50,7 +52,8 @@ mod tests {
                 hello world
                 <a><b cond=\"no\"><c>derp</c></b></a>
                 <tag>yadda yadda we dont care</tag>
-            </extensions>"
+            </extensions>",
+            GpxVersion::Gpx11
         );
 
         assert!(result.is_ok());

--- a/src/parser/fix.rs
+++ b/src/parser/fix.rs
@@ -1,16 +1,16 @@
 //! fix handles parsing of xsd:simpleType "fixType".
 
 use errors::*;
-use std::iter::Peekable;
 use std::io::Read;
-use xml::reader::Events;
 
 use parser::string;
+use parser::Context;
+
 use types::Fix;
 
 /// consume consumes an element as a fix.
-pub fn consume<R: Read>(reader: &mut Peekable<Events<R>>) -> Result<Fix> {
-    let fix_string = string::consume(reader)?;
+pub fn consume<R: Read>(context: &mut Context<R>) -> Result<Fix> {
+    let fix_string = string::consume(context)?;
 
     let fix = match fix_string.as_ref() {
         "none" => Fix::None,
@@ -30,30 +30,33 @@ mod tests {
     use xml::reader::EventReader;
 
     use super::consume;
+
+    use GpxVersion;
     use Fix;
+    use parser::Context;
 
     #[test]
     fn consume_fix() {
-        let result = consume!("<fix>dgps</fix>");
+        let result = consume!("<fix>dgps</fix>", GpxVersion::Gpx11);
         assert!(result.is_ok());
 
-        let result = consume!("<fix>none</fix>");
+        let result = consume!("<fix>none</fix>", GpxVersion::Gpx11);
         assert_eq!(result.unwrap(), Fix::None);
 
-        let result = consume!("<fix>2d</fix>");
+        let result = consume!("<fix>2d</fix>", GpxVersion::Gpx11);
         assert_eq!(result.unwrap(), Fix::TwoDimensional);
 
-        let result = consume!("<fix>3d</fix>");
+        let result = consume!("<fix>3d</fix>", GpxVersion::Gpx11);
         assert_eq!(result.unwrap(), Fix::ThreeDimensional);
 
-        let result = consume!("<fix>dgps</fix>");
+        let result = consume!("<fix>dgps</fix>", GpxVersion::Gpx11);
         assert_eq!(result.unwrap(), Fix::DGPS);
 
-        let result = consume!("<fix>pps</fix>");
+        let result = consume!("<fix>pps</fix>", GpxVersion::Gpx11);
         assert_eq!(result.unwrap(), Fix::PPS);
 
         // Not in the specification
-        let result = consume!("<fix>KF_4SV_OR_MORE</fix>");
+        let result = consume!("<fix>KF_4SV_OR_MORE</fix>", GpxVersion::Gpx11);
         assert_eq!(result.unwrap(), Fix::Other("KF_4SV_OR_MORE".to_owned()));
     }
 }

--- a/src/parser/gpx.rs
+++ b/src/parser/gpx.rs
@@ -11,6 +11,7 @@ use parser::metadata;
 use parser::waypoint;
 
 use Gpx;
+use GpxVersion;
 
 enum ParseEvent {
     StartMetadata,
@@ -18,6 +19,15 @@ enum ParseEvent {
     StartWaypoint,
     Ignore,
     EndGpx,
+}
+
+/// Convert the version string to the version enum
+fn version_string_to_version(version_str: &str) -> Result<GpxVersion> {
+    match version_str {
+        "1.0" => Ok(GpxVersion::Gpx10),
+        "1.1" => Ok(GpxVersion::Gpx11),
+        version => Err(Error::from(format!("Unknown version {}", version))),
+    }
 }
 
 /// consume consumes an entire GPX element.
@@ -31,18 +41,34 @@ pub fn consume<R: Read>(reader: &mut Peekable<Events<R>>) -> Result<Gpx> {
         let event: Result<ParseEvent> = {
             if let Some(next) = reader.peek() {
                 match next {
-                    &Ok(XmlEvent::StartElement { ref name, .. }) => {
-                        match name.local_name.as_ref() {
-                            "metadata" => Ok(ParseEvent::StartMetadata),
-                            "trk" => Ok(ParseEvent::StartTrack),
-                            "wpt" => Ok(ParseEvent::StartWaypoint),
-                            "gpx" => Ok(ParseEvent::Ignore),
-                            child => Err(Error::from(ErrorKind::InvalidChildElement(
-                                String::from(child),
-                                "gpx",
-                            )))?,
+                    &Ok(XmlEvent::StartElement {
+                        ref name,
+                        ref attributes,
+                        ..
+                    }) => match name.local_name.as_ref() {
+                        "metadata" => Ok(ParseEvent::StartMetadata),
+                        "trk" => Ok(ParseEvent::StartTrack),
+                        "wpt" => Ok(ParseEvent::StartWaypoint),
+                        "gpx" => {
+                            if let Ok(version) = attributes
+                                .iter()
+                                .filter(|attr| attr.name.local_name == "version")
+                                .nth(0)
+                                .ok_or("no version found".to_owned())
+                            {
+                                gpx.version = version_string_to_version(&version.value)?;
+                                Ok(ParseEvent::Ignore)
+                            } else {
+                                Err(Error::from(ErrorKind::InvalidElementLacksAttribute(
+                                    "version",
+                                )))
+                            }
                         }
-                    }
+                        child => Err(Error::from(ErrorKind::InvalidChildElement(
+                            String::from(child),
+                            "gpx",
+                        )))?,
+                    },
 
                     &Ok(XmlEvent::EndElement { .. }) => Ok(ParseEvent::EndGpx),
 
@@ -87,20 +113,36 @@ mod tests {
     use xml::reader::EventReader;
     use geo::Point;
 
+    use GpxVersion;
+
     use super::consume;
 
     #[test]
     fn consume_gpx() {
-        let gpx = consume!("<gpx></gpx>");
+        let gpx = consume!("<gpx version=\"1.1\"></gpx>");
 
         assert!(gpx.is_ok());
+    }
+
+    #[test]
+    fn consume_gpx_no_version() {
+        let gpx = consume!("<gpx></gpx>");
+
+        assert!(gpx.is_err());
+    }
+
+    #[test]
+    fn consume_gpx_version_error() {
+        let gpx = consume!("<gpx version=\"1.2\"></gpx>");
+
+        assert!(gpx.is_err());
     }
 
     #[test]
     fn consume_gpx_full() {
         let gpx = consume!(
             "
-            <gpx>
+            <gpx version=\"1.0\">
                 <trk></trk>
                 <wpt lat=\"1.23\" lon=\"2.34\"></wpt>
                 <wpt lon=\"10.256\" lat=\"-81.324\">
@@ -113,6 +155,7 @@ mod tests {
         assert!(gpx.is_ok());
         let gpx = gpx.unwrap();
 
+        assert_eq!(gpx.version, GpxVersion::Gpx10);
         assert_eq!(gpx.tracks.len(), 1);
 
         assert_eq!(gpx.waypoints.len(), 2);

--- a/src/parser/gpx.rs
+++ b/src/parser/gpx.rs
@@ -2,20 +2,36 @@
 
 use errors::*;
 use std::io::Read;
-use std::iter::Peekable;
-use xml::reader::Events;
 use xml::reader::XmlEvent;
+use geo::Bbox;
+use chrono::{DateTime, Utc};
 
+use parser::bounds;
+use parser::time;
+use parser::string;
 use parser::track;
 use parser::metadata;
 use parser::waypoint;
+use parser::Context;
 
 use Gpx;
 use GpxVersion;
+use Link;
+use Person;
+use Metadata;
 
 enum ParseEvent {
+    StartAuthor,      // GPX 1.0
+    StartBounds,      // GPX 1.0
+    StartDescription, // GPX 1.0
+    StartEmail,       // GPX 1.0
+    StartKeywords,    // GPX 1.0
     StartMetadata,
+    StartName, // GPX 1.0
+    StartTime, // GPX 1.0
     StartTrack,
+    StartUrl,     // GPX 1.0
+    StartUrlname, // GPX 1.0
     StartWaypoint,
     Ignore,
     EndGpx,
@@ -31,22 +47,34 @@ fn version_string_to_version(version_str: &str) -> Result<GpxVersion> {
 }
 
 /// consume consumes an entire GPX element.
-pub fn consume<R: Read>(reader: &mut Peekable<Events<R>>) -> Result<Gpx> {
+pub fn consume<R: Read>(context: &mut Context<R>) -> Result<Gpx> {
     let mut gpx: Gpx = Default::default();
+
+    let mut author: Option<String> = None;
+    let mut url: Option<String> = None;
+    let mut urlname: Option<String> = None;
+    let mut email: Option<String> = None;
+    let mut time: Option<DateTime<Utc>> = None;
+    let mut bounds: Option<Bbox<f64>> = None;
+    let mut name: Option<String> = None;
+    let mut description: Option<String> = None;
+    let mut keywords: Option<String> = None;
 
     loop {
         // Peep into the reader and see what type of event is next. Based on
         // that information, we'll either forward the event to a downstream
         // module or take the information for ourselves.
         let event: Result<ParseEvent> = {
-            if let Some(next) = reader.peek() {
+            if let Some(next) = context.reader.peek() {
                 match next {
                     &Ok(XmlEvent::StartElement {
                         ref name,
                         ref attributes,
                         ..
                     }) => match name.local_name.as_ref() {
-                        "metadata" => Ok(ParseEvent::StartMetadata),
+                        "metadata" if context.version != GpxVersion::Gpx10 => {
+                            Ok(ParseEvent::StartMetadata)
+                        }
                         "trk" => Ok(ParseEvent::StartTrack),
                         "wpt" => Ok(ParseEvent::StartWaypoint),
                         "gpx" => {
@@ -57,12 +85,34 @@ pub fn consume<R: Read>(reader: &mut Peekable<Events<R>>) -> Result<Gpx> {
                                 .ok_or("no version found".to_owned())
                             {
                                 gpx.version = version_string_to_version(&version.value)?;
+                                context.version = gpx.version;
                                 Ok(ParseEvent::Ignore)
                             } else {
                                 Err(Error::from(ErrorKind::InvalidElementLacksAttribute(
                                     "version",
                                 )))
                             }
+                        }
+                        "time" if context.version == GpxVersion::Gpx10 => Ok(ParseEvent::StartTime),
+                        "bounds" if context.version == GpxVersion::Gpx10 => {
+                            Ok(ParseEvent::StartBounds)
+                        }
+                        "author" if context.version == GpxVersion::Gpx10 => {
+                            Ok(ParseEvent::StartAuthor)
+                        }
+                        "email" if context.version == GpxVersion::Gpx10 => {
+                            Ok(ParseEvent::StartEmail)
+                        }
+                        "url" if context.version == GpxVersion::Gpx10 => Ok(ParseEvent::StartUrl),
+                        "urlname" if context.version == GpxVersion::Gpx10 => {
+                            Ok(ParseEvent::StartUrlname)
+                        }
+                        "name" if context.version == GpxVersion::Gpx10 => Ok(ParseEvent::StartName),
+                        "description" if context.version == GpxVersion::Gpx10 => {
+                            Ok(ParseEvent::StartDescription)
+                        }
+                        "keywords" if context.version == GpxVersion::Gpx10 => {
+                            Ok(ParseEvent::StartKeywords)
                         }
                         child => Err(Error::from(ErrorKind::InvalidChildElement(
                             String::from(child),
@@ -81,23 +131,78 @@ pub fn consume<R: Read>(reader: &mut Peekable<Events<R>>) -> Result<Gpx> {
 
         match event.chain_err(|| Error::from("error while parsing gpx event"))? {
             ParseEvent::Ignore => {
-                reader.next();
+                context.reader.next();
+            }
+
+            ParseEvent::StartAuthor => {
+                author = Some(string::consume(context)?);
+            }
+
+            ParseEvent::StartBounds => {
+                bounds = Some(bounds::consume(context)?);
+            }
+
+            ParseEvent::StartEmail => {
+                email = Some(string::consume(context)?);
             }
 
             ParseEvent::StartMetadata => {
-                gpx.metadata = Some(metadata::consume(reader)?);
+                gpx.metadata = Some(metadata::consume(context)?);
+            }
+
+            ParseEvent::StartName => {
+                name = Some(string::consume(context)?);
+            }
+
+            ParseEvent::StartTime => {
+                time = Some(time::consume(context)?);
+            }
+
+            ParseEvent::StartUrl => {
+                url = Some(string::consume(context)?);
+            }
+
+            ParseEvent::StartUrlname => {
+                urlname = Some(string::consume(context)?);
+            }
+
+            ParseEvent::StartDescription => {
+                description = Some(string::consume(context)?);
+            }
+
+            ParseEvent::StartKeywords => {
+                keywords = Some(string::consume(context)?);
             }
 
             ParseEvent::StartTrack => {
-                gpx.tracks.push(track::consume(reader)?);
+                gpx.tracks.push(track::consume(context)?);
             }
 
             ParseEvent::StartWaypoint => {
-                gpx.waypoints.push(waypoint::consume(reader)?);
+                gpx.waypoints.push(waypoint::consume(context)?);
             }
 
             ParseEvent::EndGpx => {
-                reader.next();
+                if gpx.version == GpxVersion::Gpx10 {
+                    let mut metadata: Metadata = Default::default();
+                    metadata.name = name;
+                    metadata.time = time;
+                    metadata.bounds = bounds;
+                    let mut person: Person = Default::default();
+                    person.name = author;
+                    if let Some(url) = url {
+                        let mut link: Link = Default::default();
+                        link.href = url;
+                        link.text = urlname;
+                        person.link = Some(link);
+                    }
+                    person.email = email;
+                    metadata.author = Some(person);
+                    metadata.keywords = keywords;
+                    metadata.description = description;
+                    gpx.metadata = Some(metadata);
+                }
+                context.reader.next();
 
                 return Ok(gpx);
             }
@@ -114,26 +219,26 @@ mod tests {
     use geo::Point;
 
     use GpxVersion;
-
+    use parser::Context;
     use super::consume;
 
     #[test]
     fn consume_gpx() {
-        let gpx = consume!("<gpx version=\"1.1\"></gpx>");
+        let gpx = consume!("<gpx version=\"1.1\"></gpx>", GpxVersion::Unknown);
 
         assert!(gpx.is_ok());
     }
 
     #[test]
     fn consume_gpx_no_version() {
-        let gpx = consume!("<gpx></gpx>");
+        let gpx = consume!("<gpx></gpx>", GpxVersion::Unknown);
 
         assert!(gpx.is_err());
     }
 
     #[test]
     fn consume_gpx_version_error() {
-        let gpx = consume!("<gpx version=\"1.2\"></gpx>");
+        let gpx = consume!("<gpx version=\"1.2\"></gpx>", GpxVersion::Unknown);
 
         assert!(gpx.is_err());
     }
@@ -143,13 +248,16 @@ mod tests {
         let gpx = consume!(
             "
             <gpx version=\"1.0\">
+                <time>2016-03-27T18:57:55Z</time>
+                <bounds minlat=\"45.487064362\" minlon=\"-74.031837463\" maxlat=\"45.701225281\" maxlon=\"-73.586273193\"></bounds>
                 <trk></trk>
                 <wpt lat=\"1.23\" lon=\"2.34\"></wpt>
                 <wpt lon=\"10.256\" lat=\"-81.324\">
                     <time>2001-10-26T19:32:52+00:00</time>
                 </wpt>
             </gpx>
-            "
+            ",
+            GpxVersion::Unknown
         );
 
         assert!(gpx.is_ok());

--- a/src/parser/metadata.rs
+++ b/src/parser/metadata.rs
@@ -10,6 +10,7 @@ use parser::link;
 use parser::string;
 use parser::person;
 use parser::time;
+use parser::bounds;
 
 use Metadata;
 
@@ -20,6 +21,7 @@ enum ParseEvent {
     StartKeywords,
     StartTime,
     StartLink,
+    StartBounds,
     Ignore,
     EndMetadata,
 }
@@ -43,6 +45,7 @@ pub fn consume<R: Read>(reader: &mut Peekable<Events<R>>) -> Result<Metadata> {
                             "keywords" => Ok(ParseEvent::StartKeywords),
                             "time" => Ok(ParseEvent::StartTime),
                             "link" => Ok(ParseEvent::StartLink),
+                            "bounds" => Ok(ParseEvent::StartBounds),
                             child => Err(Error::from(ErrorKind::InvalidChildElement(
                                 String::from(child),
                                 "metadata",
@@ -86,6 +89,10 @@ pub fn consume<R: Read>(reader: &mut Peekable<Events<R>>) -> Result<Metadata> {
 
             ParseEvent::StartLink => {
                 metadata.links.push(link::consume(reader)?);
+            }
+
+            ParseEvent::StartBounds => {
+                metadata.bounds = Some(bounds::consume(reader)?);
             }
 
             ParseEvent::EndMetadata => {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -10,6 +10,7 @@ macro_rules! consume {
     }};
 }
 
+pub mod bounds;
 pub mod email;
 pub mod extensions;
 pub mod fix;

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -4,9 +4,11 @@
 #[cfg(test)]
 #[macro_export]
 macro_rules! consume {
-    ( $xml:expr ) => {{
+    ( $xml:expr, $version:expr ) => {{
         let reader = BufReader::new($xml.as_bytes());
-        consume(&mut EventReader::new(reader).into_iter().peekable())
+        let events = EventReader::new(reader).into_iter().peekable();
+        let mut context = Context::new(events, $version);
+        consume(&mut context)
     }};
 }
 
@@ -23,3 +25,23 @@ pub mod time;
 pub mod track;
 pub mod tracksegment;
 pub mod waypoint;
+
+use std::io::Read;
+use std::iter::Peekable;
+use xml::reader::Events;
+use types::GpxVersion;
+
+pub struct Context<R: Read> {
+    reader: Peekable<Events<R>>,
+    version: GpxVersion,
+}
+
+impl<R: Read> Context<R> {
+    pub fn new(reader: Peekable<Events<R>>, version: GpxVersion) -> Context<R> {
+        Context { reader, version }
+    }
+
+    pub fn reader(&mut self) -> &mut Peekable<Events<R>> {
+        &mut self.reader
+    }
+}

--- a/src/parser/string.rs
+++ b/src/parser/string.rs
@@ -1,17 +1,17 @@
 //! string handles parsing of GPX-spec strings.
 
 use errors::*;
-use std::iter::Peekable;
 use std::io::Read;
-use xml::reader::Events;
 use xml::reader::XmlEvent;
 
+use parser::Context;
+
 /// consume consumes a single string as tag content.
-pub fn consume<R: Read>(reader: &mut Peekable<Events<R>>) -> Result<String> {
+pub fn consume<R: Read>(context: &mut Context<R>) -> Result<String> {
     let mut element: Option<String> = None;
     let mut string: Option<String> = None;
 
-    for event in reader {
+    for event in context.reader() {
         match event.chain_err(|| "error while parsing XML")? {
             XmlEvent::StartElement { name, .. } => {
                 ensure!(element.is_none(), "cannot start element inside string");
@@ -37,11 +37,13 @@ mod tests {
     use std::io::BufReader;
     use xml::reader::EventReader;
 
+    use GpxVersion;
+    use parser::Context;
     use super::consume;
 
     #[test]
     fn consume_simple_string() {
-        let result = consume!("<string>hello world</string>");
+        let result = consume!("<string>hello world</string>", GpxVersion::Gpx11);
 
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), "hello world");
@@ -50,7 +52,7 @@ mod tests {
     #[test]
     fn consume_new_tag() {
         // cannot start new tag inside string
-        let result = consume!("<foo>bar<baz></baz></foo>");
+        let result = consume!("<foo>bar<baz></baz></foo>", GpxVersion::Gpx11);
 
         assert!(result.is_err());
     }
@@ -58,7 +60,7 @@ mod tests {
     #[test]
     fn consume_start_tag() {
         // must have starting tag
-        let result = consume!("bar</foo>");
+        let result = consume!("bar</foo>", GpxVersion::Gpx11);
 
         assert!(result.is_err());
     }
@@ -66,7 +68,7 @@ mod tests {
     #[test]
     fn consume_end_tag() {
         // must have ending tag
-        let result = consume!("<foo>bar");
+        let result = consume!("<foo>bar", GpxVersion::Gpx11);
 
         assert!(result.is_err());
     }
@@ -74,7 +76,7 @@ mod tests {
     #[test]
     fn consume_no_body() {
         // must have string content
-        let result = consume!("<foo></foo>");
+        let result = consume!("<foo></foo>", GpxVersion::Gpx11);
 
         assert!(result.is_err());
     }
@@ -82,7 +84,7 @@ mod tests {
     #[test]
     fn consume_different_ending_tag() {
         // this is just illegal
-        let result = consume!("<foo></foobar>");
+        let result = consume!("<foo></foobar>", GpxVersion::Gpx11);
 
         assert!(result.is_err());
     }

--- a/src/parser/time.rs
+++ b/src/parser/time.rs
@@ -3,18 +3,17 @@
 /// format: [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
 
 use errors::*;
-use std::iter::Peekable;
 use std::io::Read;
-use xml::reader::Events;
 
 use chrono::DateTime;
 use chrono::prelude::Utc;
 
 use parser::string;
+use parser::Context;
 
 /// consume consumes an element as a time.
-pub fn consume<R: Read>(reader: &mut Peekable<Events<R>>) -> Result<DateTime<Utc>> {
-    let time = string::consume(reader)?;
+pub fn consume<R: Read>(context: &mut Context<R>) -> Result<DateTime<Utc>> {
+    let time = string::consume(context)?;
 
     let time =
         DateTime::parse_from_rfc3339(&time).chain_err(|| "error while parsing time as RFC3339")?;
@@ -27,11 +26,13 @@ mod tests {
     use std::io::BufReader;
     use xml::reader::EventReader;
 
+    use GpxVersion;
+    use parser::Context;
     use super::consume;
 
     #[test]
     fn consume_time() {
-        let result = consume!("<time>1996-12-19T16:39:57-08:00</time>");
+        let result = consume!("<time>1996-12-19T16:39:57-08:00</time>", GpxVersion::Gpx11);
         assert!(result.is_ok());
 
         // The following examples are taken from the xsd:dateTime examples.
@@ -41,32 +42,32 @@ mod tests {
         // let result = consume!("<time>2001-10-26T21:32:52</time>");
         // assert!(result.is_ok());
 
-        let result = consume!("<time>2001-10-26T21:32:52+02:00</time>");
+        let result = consume!("<time>2001-10-26T21:32:52+02:00</time>", GpxVersion::Gpx11);
         assert!(result.is_ok());
 
-        let result = consume!("<time>2001-10-26T19:32:52Z</time>");
+        let result = consume!("<time>2001-10-26T19:32:52Z</time>", GpxVersion::Gpx11);
         assert!(result.is_ok());
 
-        let result = consume!("<time>2001-10-26T19:32:52+00:00</time>");
+        let result = consume!("<time>2001-10-26T19:32:52+00:00</time>", GpxVersion::Gpx11);
         assert!(result.is_ok());
 
-        // let result = consume!("<time>-2001-10-26T21:32:52</time>");
+        // let result = consume!("<time>-2001-10-26T21:32:52</time>", GpxVersion::Gpx11);
         // assert!(result.is_ok());
 
-        // let result = consume!("<time>2001-10-26T21:32:52.12679</time>");
+        // let result = consume!("<time>2001-10-26T21:32:52.12679</time>", GpxVersion::Gpx11);
         // assert!(result.is_ok());
 
         // These are invalid, again, from xsd:dateTime examples.
-        let result = consume!("<time>2001-10-26</time>");
+        let result = consume!("<time>2001-10-26</time>", GpxVersion::Gpx11);
         assert!(result.is_err());
 
-        let result = consume!("<time>2001-10-26T21:32</time>");
+        let result = consume!("<time>2001-10-26T21:32</time>", GpxVersion::Gpx11);
         assert!(result.is_err());
 
-        let result = consume!("<time>2001-10-26T25:32:52+02:00</time>");
+        let result = consume!("<time>2001-10-26T25:32:52+02:00</time>", GpxVersion::Gpx11);
         assert!(result.is_err());
 
-        let result = consume!("<time>01-10-26T21:32</time>");
+        let result = consume!("<time>01-10-26T21:32</time>", GpxVersion::Gpx11);
         assert!(result.is_err());
     }
 }

--- a/src/parser/waypoint.rs
+++ b/src/parser/waypoint.rs
@@ -2,8 +2,6 @@
 
 use errors::*;
 use std::io::Read;
-use std::iter::Peekable;
-use xml::reader::Events;
 use xml::reader::XmlEvent;
 use geo::Point;
 use chrono::prelude::*;
@@ -13,16 +11,20 @@ use parser::link;
 use parser::time;
 use parser::fix;
 use parser::extensions;
+use parser::Context;
 
 use Link;
 use Waypoint;
 use Fix;
 
+use GpxVersion;
+
 /// consume consumes a GPX waypoint from the `reader` until it ends.
-pub fn consume<R: Read>(reader: &mut Peekable<Events<R>>) -> Result<Waypoint> {
+pub fn consume<R: Read>(context: &mut Context<R>) -> Result<Waypoint> {
     // Here we hold all members of a waypoint, just outside of the struct.
     let mut point: Option<Point<f64>> = None;
     let mut elevation: Option<f64> = None;
+    let mut speed: Option<f64> = None; // Only in GPX 1.0
     let mut time: Option<DateTime<Utc>> = None;
     let mut wptname: Option<String> = None;
     let mut comment: Option<String> = None;
@@ -39,7 +41,7 @@ pub fn consume<R: Read>(reader: &mut Peekable<Events<R>>) -> Result<Waypoint> {
     let mut age_of_gps_data: Option<f64> = None; // Seconds since last DGPS update (decimal)
     let mut dgpsid: Option<u16> = None; // Id of the DGPS station (integer 0-1023)
 
-    while let Some(event) = reader.next() {
+    while let Some(event) = context.reader.next() {
         match event.chain_err(|| "error while parsing XML")? {
             XmlEvent::StartElement {
                 name, attributes, ..
@@ -75,54 +77,60 @@ pub fn consume<R: Read>(reader: &mut Peekable<Events<R>>) -> Result<Waypoint> {
                     }
                     "ele" => {
                         // Cast the elevation to an f64, from a string.
-                        elevation = Some(string::consume(reader)?
+                        elevation = Some(string::consume(context)?
                             .parse()
                             .chain_err(|| "error while casting elevation to f64")?)
                     }
-                    "time" => time = Some(time::consume(reader)?),
-                    "name" => wptname = Some(string::consume(reader)?),
-                    "cmt" => comment = Some(string::consume(reader)?),
-                    "desc" => description = Some(string::consume(reader)?),
-                    "src" => source = Some(string::consume(reader)?),
-                    "link" => links.push(link::consume(reader)?),
-                    "sym" => symbol = Some(string::consume(reader)?),
-                    "type" => _type = Some(string::consume(reader)?),
+                    "speed" if context.version == GpxVersion::Gpx10 => {
+                        // Speed is from GPX 1.0
+                        speed = Some(string::consume(context)?
+                            .parse()
+                            .chain_err(|| "error while casting speed to f64")?);
+                    }
+                    "time" => time = Some(time::consume(context)?),
+                    "name" => wptname = Some(string::consume(context)?),
+                    "cmt" => comment = Some(string::consume(context)?),
+                    "desc" => description = Some(string::consume(context)?),
+                    "src" => source = Some(string::consume(context)?),
+                    "link" => links.push(link::consume(context)?),
+                    "sym" => symbol = Some(string::consume(context)?),
+                    "type" => _type = Some(string::consume(context)?),
 
                     // Optional accuracy information
-                    "fix" => fix = Some(fix::consume(reader)?),
+                    "fix" => fix = Some(fix::consume(context)?),
                     "sat" => {
-                        sat = Some(string::consume(reader)?
+                        sat = Some(string::consume(context)?
                             .parse()
                             .chain_err(|| "error while casting number of satellites (sat) to u64")?)
                     }
                     "hdop" => {
-                        hdop = Some(string::consume(reader)?.parse().chain_err(|| {
+                        hdop = Some(string::consume(context)?.parse().chain_err(|| {
                             "error while casting horizontal dilution of precision (hdop) to f64"
                         })?)
                     }
                     "vdop" => {
-                        vdop = Some(string::consume(reader)?.parse().chain_err(|| {
+                        vdop = Some(string::consume(context)?.parse().chain_err(|| {
                             "error while casting vertical dilution of precision (vdop) to f64"
                         })?)
                     }
                     "pdop" => {
-                        pdop = Some(string::consume(reader)?.parse().chain_err(|| {
+                        pdop = Some(string::consume(context)?.parse().chain_err(|| {
                             "error while casting position dilution of precision (pdop) to f64"
                         })?)
                     }
                     "ageofgpsdata" => {
-                        age_of_gps_data = Some(string::consume(reader)?
+                        age_of_gps_data = Some(string::consume(context)?
                             .parse()
                             .chain_err(|| "error while casting age of GPS data to f64")?)
                     }
                     "dgpsid" => {
-                        dgpsid = Some(string::consume(reader)?
+                        dgpsid = Some(string::consume(context)?
                             .parse()
                             .chain_err(|| "error while casting DGPS station ID to u16")?)
                     }
 
                     // Finally the GPX 1.1 extensions
-                    "extensions" => extensions::consume(reader)?,
+                    "extensions" => extensions::consume(context)?,
                     child => Err(Error::from(ErrorKind::InvalidChildElement(
                         String::from(child),
                         "waypoint",
@@ -149,6 +157,7 @@ pub fn consume<R: Read>(reader: &mut Peekable<Events<R>>) -> Result<Waypoint> {
                 wpt.hdop = hdop;
                 wpt.vdop = vdop;
                 wpt.pdop = pdop;
+                wpt.speed = speed;
                 wpt.age = age_of_gps_data;
                 wpt.dgpsid = dgpsid;
 
@@ -168,7 +177,9 @@ mod tests {
     use xml::reader::EventReader;
     use geo::Point;
 
+    use GpxVersion;
     use Fix;
+    use parser::Context;
     use super::consume;
 
     #[test]
@@ -185,8 +196,10 @@ mod tests {
                 <fix>dgps</fix>
                 <sat>4</sat>
                 <hdop>6.058</hdop>
+                <speed>0.0000</speed>
             </wpt>
-            "
+            ",
+            GpxVersion::Gpx10
         );
 
         assert!(waypoint.is_ok());
@@ -213,7 +226,10 @@ mod tests {
 
     #[test]
     fn consume_empty() {
-        let waypoint = consume!("<trkpt lat=\"2.345\" lon=\"1.234\"></trkpt>");
+        let waypoint = consume!(
+            "<trkpt lat=\"2.345\" lon=\"1.234\"></trkpt>",
+            GpxVersion::Gpx11
+        );
 
         assert!(waypoint.is_ok());
         let waypoint = waypoint.unwrap();
@@ -225,7 +241,10 @@ mod tests {
 
     #[test]
     fn consume_bad_waypoint() {
-        let waypoint = consume!("<wpt lat=\"32.4\" lon=\"notanumber\"></wpt>");
+        let waypoint = consume!(
+            "<wpt lat=\"32.4\" lon=\"notanumber\"></wpt>",
+            GpxVersion::Gpx11
+        );
 
         assert!(waypoint.is_err());
     }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -5,8 +5,9 @@ use std::io::Read;
 use errors::*;
 use xml::reader::EventReader;
 
-use parser::gpx;
+use parser::{gpx, Context};
 use Gpx;
+use GpxVersion;
 
 /// Reads an activity in GPX format.
 ///
@@ -36,7 +37,8 @@ use Gpx;
 /// ```
 pub fn read<R: Read>(reader: R) -> Result<Gpx> {
     let parser = EventReader::new(reader);
-    let mut events = parser.into_iter().peekable();
+    let events = parser.into_iter().peekable();
+    let mut context = Context::new(events, GpxVersion::Unknown);
 
-    return gpx::consume(&mut events);
+    return gpx::consume(&mut context);
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -6,7 +6,7 @@ use geo::{Bbox, LineString, MultiLineString, Point};
 use chrono::DateTime;
 use chrono::prelude::Utc;
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum GpxVersion {
     Unknown,
     Gpx10,
@@ -181,6 +181,9 @@ pub struct Waypoint {
     /// Elevation (in meters) of the point.
     pub elevation: Option<f64>,
 
+    /// Speed (in meters per second) (only in GPX 1.0)
+    pub speed: Option<f64>,
+
     /// Creation/modification timestamp for element. Date and time in are in
     /// Univeral Coordinated Time (UTC), not local time! Conforms to ISO 8601
     /// specification for date/time representation. Fractional seconds are
@@ -286,6 +289,7 @@ impl Waypoint {
         Waypoint {
             point: point,
             elevation: None,
+            speed: None,
             time: None,
             name: None,
             comment: None,

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,7 +1,7 @@
 //! generic types for GPX
 
 use geo::{Geometry, ToGeo};
-use geo::{LineString, MultiLineString, Point};
+use geo::{Bbox, LineString, MultiLineString, Point};
 
 use chrono::DateTime;
 use chrono::prelude::Utc;
@@ -46,7 +46,8 @@ pub struct Metadata {
     /// this information to classify the data.
     pub keywords: Option<String>,
     /*copyright: GpxCopyrightType,*/
-    /*pub bounds: Option<Bbox<f64>>,*/
+    /// Bounds for the tracks in the GPX.
+    pub bounds: Option<Bbox<f64>>,
     /*extensions: GpxExtensionsType,*/
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -6,10 +6,24 @@ use geo::{Bbox, LineString, MultiLineString, Point};
 use chrono::DateTime;
 use chrono::prelude::Utc;
 
+#[derive(Clone, Debug, PartialEq)]
+pub enum GpxVersion {
+    Unknown,
+    Gpx10,
+    Gpx11,
+}
+
+impl Default for GpxVersion {
+    fn default() -> GpxVersion {
+        GpxVersion::Unknown
+    }
+}
+
 /// Gpx is the root element in the XML file.
 #[derive(Clone, Default, Debug)]
 pub struct Gpx {
-    pub version: String,
+    /// Version of the Gpx file.
+    pub version: GpxVersion,
 
     /// Metadata about the file.
     pub metadata: Option<Metadata>,


### PR DESCRIPTION
GPX is still generated by gpsbabel when loading tracks from various devices.

The PR add support for the GPX 1.0 format.