### PR TITLE
Include the child tag name into 'InvalidChildElement' error.

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -5,9 +5,9 @@ error_chain!{
     errors {
         /// InvalidChildElement signifies when an element has a child that isn't
         /// valid per the GPX spec.
-        InvalidChildElement(parent: &'static str) {
+        InvalidChildElement(child: String, parent: &'static str) {
             description("invalid child element")
-            display("invalid child element in {}", String::from(*parent))
+            display("invalid child element '{}' in {}", child, String::from(*parent))
         }
 
         /// InvalidElementLacksAttribute signifies when an element is missing a

--- a/src/parser/email.rs
+++ b/src/parser/email.rs
@@ -40,7 +40,10 @@ pub fn consume<R: Read>(reader: &mut Peekable<Events<R>>) -> Result<String> {
 
                         email = Some(format!("{id}@{domain}", id = id, domain = domain));
                     }
-                    _ => Err(Error::from(ErrorKind::InvalidChildElement("email")))?,
+                    child => Err(Error::from(ErrorKind::InvalidChildElement(
+                        String::from(child),
+                        "email",
+                    )))?,
                 }
             }
 
@@ -117,7 +120,7 @@ mod tests {
         let err = consume!("<email id=\"id\" domain=\"domain\"><child /></email>").unwrap_err();
 
         assert_eq!(err.description(), "invalid child element");
-        assert_eq!(err.to_string(), "invalid child element in email");
+        assert_eq!(err.to_string(), "invalid child element 'child' in email");
     }
 
     #[test]

--- a/src/parser/gpx.rs
+++ b/src/parser/gpx.rs
@@ -37,7 +37,10 @@ pub fn consume<R: Read>(reader: &mut Peekable<Events<R>>) -> Result<Gpx> {
                             "trk" => Ok(ParseEvent::StartTrack),
                             "wpt" => Ok(ParseEvent::StartWaypoint),
                             "gpx" => Ok(ParseEvent::Ignore),
-                            _ => Err(Error::from(ErrorKind::InvalidChildElement("gpx")))?,
+                            child => Err(Error::from(ErrorKind::InvalidChildElement(
+                                String::from(child),
+                                "gpx",
+                            )))?,
                         }
                     }
 

--- a/src/parser/link.rs
+++ b/src/parser/link.rs
@@ -35,7 +35,10 @@ pub fn consume<R: Read>(reader: &mut Peekable<Events<R>>) -> Result<Link> {
 
                         link.href = attr.value;
                     }
-                    _ => Err(Error::from(ErrorKind::InvalidChildElement("link")))?,
+                    child => Err(Error::from(ErrorKind::InvalidChildElement(
+                        String::from(child),
+                        "link",
+                    )))?,
                 }
             }
 

--- a/src/parser/metadata.rs
+++ b/src/parser/metadata.rs
@@ -43,7 +43,10 @@ pub fn consume<R: Read>(reader: &mut Peekable<Events<R>>) -> Result<Metadata> {
                             "keywords" => Ok(ParseEvent::StartKeywords),
                             "time" => Ok(ParseEvent::StartTime),
                             "link" => Ok(ParseEvent::StartLink),
-                            _ => Err(Error::from(ErrorKind::InvalidChildElement("metadata")))?,
+                            child => Err(Error::from(ErrorKind::InvalidChildElement(
+                                String::from(child),
+                                "metadata",
+                            )))?,
                         }
                     }
 

--- a/src/parser/person.rs
+++ b/src/parser/person.rs
@@ -37,7 +37,10 @@ pub fn consume<R: Read>(reader: &mut Peekable<Events<R>>) -> Result<Person> {
                             "link" => Ok(ParseEvent::StartLink),
                             "person" => Ok(ParseEvent::Ignore),
                             "author" => Ok(ParseEvent::Ignore),
-                            _ => Err(Error::from(ErrorKind::InvalidChildElement("person"))),
+                            child => Err(Error::from(ErrorKind::InvalidChildElement(
+                                String::from(child),
+                                "person",
+                            ))),
                         }
                     }
 

--- a/src/parser/track.rs
+++ b/src/parser/track.rs
@@ -25,7 +25,10 @@ pub fn consume<R: Read>(reader: &mut Peekable<Events<R>>) -> Result<Track> {
                 "src" => track.source = Some(string::consume(reader)?),
                 "type" => track._type = Some(string::consume(reader)?),
                 "trkseg" => track.segments.push(tracksegment::consume(reader)?),
-                _ => Err(Error::from(ErrorKind::InvalidChildElement("track")))?,
+                child => Err(Error::from(ErrorKind::InvalidChildElement(
+                    String::from(child),
+                    "track",
+                )))?,
             },
 
             XmlEvent::EndElement { .. } => {

--- a/src/parser/tracksegment.rs
+++ b/src/parser/tracksegment.rs
@@ -32,7 +32,10 @@ pub fn consume<R: Read>(reader: &mut Peekable<Events<R>>) -> Result<TrackSegment
                         match name.local_name.as_ref() {
                             "trkseg" => Ok(TrackSegmentEvent::StartTrkSeg),
                             "trkpt" => Ok(TrackSegmentEvent::StartTrkPt),
-                            _ => Err(Error::from(ErrorKind::InvalidChildElement("tracksegment"))),
+                            child => Err(Error::from(ErrorKind::InvalidChildElement(
+                                String::from(child),
+                                "tracksegment",
+                            ))),
                         }
                     }
 

--- a/src/parser/waypoint.rs
+++ b/src/parser/waypoint.rs
@@ -123,7 +123,10 @@ pub fn consume<R: Read>(reader: &mut Peekable<Events<R>>) -> Result<Waypoint> {
 
                     // Finally the GPX 1.1 extensions
                     "extensions" => extensions::consume(reader)?,
-                    _ => Err(Error::from(ErrorKind::InvalidChildElement("waypoint")))?,
+                    child => Err(Error::from(ErrorKind::InvalidChildElement(
+                        String::from(child),
+                        "waypoint",
+                    )))?,
                 }
             }
 


### PR DESCRIPTION
This makes the error much more useful. Including the actual name of a tag that caused problem makes it possible to figure out what's wrong with the gpx file without having to go through the library code finding out what did it expect.

### Full context

I've been trying to parse the gpx track from my Garmin device, but `gpx::read` errored out with:
```
invalid child element in track
```

I opened the file and saw the following:

```xml
<?xml version="1.0" encoding="UTF-8" standalone="no"?>
<gpx xmlns="http://www.topografix.com/GPX/1/1" xmlns:gpxx="http://www.garmin.com/xmlschemas/GpxExtensions/v3" xmlns:gpxtrkx="http://www.garmin.com/xmlschemas/TrackStatsExtension/v1" xmlns:wptx1="http://www.garmin.com/xmlschemas/WaypointExtension/v1" xmlns:gpxtpx="http://www.garmin.com/xmlschemas/TrackPointExtension/v1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" creator="GPSMAP 64s" version="1.1" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd http://www.garmin.com/xmlschemas/GpxExtensions/v3 http://www8.garmin.com/xmlschemas/GpxExtensionsv3.xsd http://www.garmin.com/xmlschemas/TrackStatsExtension/v1 http://www8.garmin.com/xmlschemas/TrackStatsExtension.xsd http://www.garmin.com/xmlschemas/WaypointExtension/v1 http://www8.garmin.com/xmlschemas/WaypointExtensionv1.xsd http://www.garmin.com/xmlschemas/TrackPointExtension/v1 http://www.garmin.com/xmlschemas/TrackPointExtensionv1.xsd">
  <metadata>
    <link href="http://www.garmin.com">
      <text>Garmin International</text>
    </link>
    <time>2018-02-22T10:40:38Z</time>
  </metadata>
  <trk>
    <name>2018-02-22 11:40:31</name>
    <extensions>
      <gpxx:TrackExtension>
        <gpxx:DisplayColor>Blue</gpxx:DisplayColor>
      </gpxx:TrackExtension>
      <gpxtrkx:TrackStatsExtension>
        <gpxtrkx:Distance>60986</gpxtrkx:Distance>
        <gpxtrkx:TotalElapsedTime>88210</gpxtrkx:TotalElapsedTime>
        <gpxtrkx:MovingTime>14117</gpxtrkx:MovingTime>
        <gpxtrkx:StoppedTime>4865</gpxtrkx:StoppedTime>
        <gpxtrkx:MovingSpeed>4</gpxtrkx:MovingSpeed>
        <gpxtrkx:MaxSpeed>19</gpxtrkx:MaxSpeed>
        <gpxtrkx:MaxElevation>1334</gpxtrkx:MaxElevation>
        <gpxtrkx:MinElevation>1102</gpxtrkx:MinElevation>
        <gpxtrkx:Ascent>1692</gpxtrkx:Ascent>
        <gpxtrkx:Descent>1660</gpxtrkx:Descent>
        <gpxtrkx:AvgAscentRate>0</gpxtrkx:AvgAscentRate>
        <gpxtrkx:MaxAscentRate>2</gpxtrkx:MaxAscentRate>
        <gpxtrkx:AvgDescentRate>0</gpxtrkx:AvgDescentRate>
        <gpxtrkx:MaxDescentRate>-4</gpxtrkx:MaxDescentRate>
      </gpxtrkx:TrackStatsExtension>
    </extensions>
    <trkseg>
      <trkpt lat="60.4295433965" lon="7.7490838990">
        <ele>1166.69</ele>
        <time>2018-02-21T10:10:28Z</time>
      </trkpt>
      <trkpt lat="60.4295495991" lon="7.7490779478">
        <ele>1166.69</ele>
        <time>2018-02-21T10:10:29Z</time>
      </trkpt>
      <trkpt lat="60.4295322485" lon="7.7490347810">
        <ele>1166.82</ele>
        <time>2018-02-21T10:11:00Z</time>
      </trkpt>
      ...many...more...track...points....
    </trkseg>
  </trk>
</gpx>
```

It was my first time looking at GPX and my first time using rust-gpx (also the first time playing with Rust), so I couldn't tell right away which part of that XML is considered invalid. However I saw that the xml schema/namespace references some Garmin's extensions to GPX and thought that it must be what rust-gpx doesn't like.

I had a look at `src/parser/track.rs` and saw that it matches some standard tags, and for any other tag it just returns `InvalidChildElement("track")` throwing away the actual name of "invalid" element.

I didn't want to keep eyeballing my file, cross-referencing it with the list of tags expected by `track.rs`. Instead I wanted to actually improve the error message, so I made this patch which makes it produce the following error message:

```
invalid child element 'extensions' in track
```

This gives a reference to the unexpected thing and allows to easily find it in the xml file, meaning that if later somebody runs the parser on unsupported gpx file they'll have easier time figuring out the problem and reporting it.

P.S. I'm very much a rust newbie, so any improvement suggestions will be appreciated.
P.P.S. I still want to parse and process my files and also improve the experience of parsing GPX files with third-party extensions, but that'll go into another issue/PR.