### PR TITLE
release 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # CHANGELOG
 
+## 0.3.0
+
+The 0.3.0 release contains added support for GPX 1.0, "bounds" support for tracks, and improved error reporting.
+
+- [`385ca1c`](https://github.com/georust/rust-gpx/commit/385ca1c04c115a5bffa19d1606839f28ecffce5c): Support GPX 1.0 ([#6](https://github.com/georust/rust-gpx/pull/6))
+- [`9680234`](https://github.com/georust/rust-gpx/commit/9680234a8f47da0c2559ed5769d0f533cffb4eab): Handle the GPX version attribute ([#6](https://github.com/georust/rust-gpx/pull/6))
+- [`6e07049`](https://github.com/georust/rust-gpx/commit/6e07049401fbc99de0220fa796a4f5e94ab6282a): Handle bounds attribute ([#6](https://github.com/georust/rust-gpx/pull/6))
+- [`92dbb56`](https://github.com/georust/rust-gpx/commit/92dbb56564cfd9defdc9a655d0cda84af5c3ec64): Include the child tag name into 'InvalidChildElement' error. ([#7](https://github.com/georust/rust-gpx/pull/7))
+
 ## 0.2.0
 
 The 0.2.0 release contains new changes that add GPX waypoint accuracy information and `Clone` for public types.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 name = "gpx"
 description = "Rust read/write support for GPS Exchange Format (GPX)"
 license = "MIT"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Brendan Ashworth <brendan.ashworth@me.com>", "Corey Farwell <coreyf@rwell.org>"]
 readme = "README.md"
 documentation = "https://docs.rs/gpx"

--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ fn main() {
 }
 ```
 
+## Current Status
+
+rust-gpx currently supports reading both GPX 1.1 and 1.0. GPX extensions and
+writing to files are not yet supported.
+
 ## Contributing
 All contributions are welcome! Please open an issue if you find a bug / have any
 questions, and pull requests are always appreciated.

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -4,7 +4,7 @@
 #[cfg(test)]
 #[macro_export]
 macro_rules! consume {
-    ( $xml:expr, $version:expr ) => {{
+    ($xml: expr, $version: expr) => {{
         let reader = BufReader::new($xml.as_bytes());
         let events = EventReader::new(reader).into_iter().peekable();
         let mut context = Context::new(events, $version);


### PR DESCRIPTION
The 0.3.0 release contains added support for GPX 1.0, "bounds" support
for tracks, and improved error handling.