### PR TITLE
Rework parsing: More strict and (hopefully) cleaner

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -25,9 +25,9 @@ error_chain!{
 
         /// InvalidElementLacksAttribute signifies when an element is missing a
         /// required attribute.
-        InvalidElementLacksAttribute(attr: &'static str) {
+        InvalidElementLacksAttribute(attr: &'static str, parent: &'static str) {
             description("invalid element, lacks required attribute")
-            display("invalid element, lacks required attribute {}", attr)
+            display("invalid element, {} lacks required attribute {}", parent, attr)
         }
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -10,6 +10,19 @@ error_chain!{
             display("invalid child element '{}' in {}", child, parent)
         }
 
+        /// InvalidClosingTag signifies incorrect XML syntax: A tag was closed that
+        /// could not be closed at this point.
+        InvalidClosingTag(invalid_tag: String, parent: &'static str) {
+            description("invalid closing tag")
+            display("invalid closing tag '{}' in {}", invalid_tag, parent)
+        }
+
+        /// MissingClosingTag signifies incorrect XML syntax: A tag was not closed.
+        MissingClosingTag(parent: &'static str) {
+            description("missing closing tag")
+            display("missing closing tag in element '{}'", parent)
+        }
+
         /// InvalidElementLacksAttribute signifies when an element is missing a
         /// required attribute.
         InvalidElementLacksAttribute(attr: &'static str) {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -7,14 +7,14 @@ error_chain!{
         /// valid per the GPX spec.
         InvalidChildElement(child: String, parent: &'static str) {
             description("invalid child element")
-            display("invalid child element '{}' in {}", child, String::from(*parent))
+            display("invalid child element '{}' in {}", child, parent)
         }
 
         /// InvalidElementLacksAttribute signifies when an element is missing a
         /// required attribute.
         InvalidElementLacksAttribute(attr: &'static str) {
             description("invalid element, lacks required attribute")
-            display("invalid element, lacks required attribute {}", String::from(*attr))
+            display("invalid element, lacks required attribute {}", attr)
         }
     }
 }

--- a/src/parser/bounds.rs
+++ b/src/parser/bounds.rs
@@ -4,8 +4,8 @@ use geo::Bbox;
 use std::io::Read;
 use xml::reader::XmlEvent;
 
-use parser::Context;
 use parser::verify_starting_tag;
+use parser::Context;
 
 /// consume consumes a bounds element until it ends.
 pub fn consume<R: Read>(context: &mut Context<R>) -> Result<Bbox<f64>> {
@@ -84,7 +84,6 @@ mod tests {
     use std::io::BufReader;
 
     use super::consume;
-    use parser::Context;
     use GpxVersion;
 
     #[test]

--- a/src/parser/bounds.rs
+++ b/src/parser/bounds.rs
@@ -5,80 +5,78 @@ use xml::reader::XmlEvent;
 use geo::Bbox;
 
 use parser::Context;
+use parser::verify_starting_tag;
 
-/// consume consumes an element as a nothing.
+/// consume consumes a bounds element until it ends.
 pub fn consume<R: Read>(context: &mut Context<R>) -> Result<Bbox<f64>> {
-    let mut element: Option<String> = None;
-    let mut bounds: Bbox<f64> = Bbox {
-        xmin: 0.,
-        xmax: 0.,
-        ymin: 0.,
-        ymax: 0.,
+    let attributes = verify_starting_tag(context, "bounds")?;
+    // get required bounds
+    let minlat = attributes
+        .iter()
+        .filter(|attr| attr.name.local_name == "minlat")
+        .nth(0)
+        .ok_or(ErrorKind::InvalidElementLacksAttribute("minlat", "bounds"))?;
+    let maxlat = attributes
+        .iter()
+        .filter(|attr| attr.name.local_name == "maxlat")
+        .nth(0)
+        .ok_or(ErrorKind::InvalidElementLacksAttribute("maxlat", "bounds"))?;
+
+    let minlat: f64 = minlat
+        .value
+        .parse()
+        .chain_err(|| "error while casting min latitude to f64")?;
+    let maxlat: f64 = maxlat
+        .value
+        .parse()
+        .chain_err(|| "error while casting max latitude to f64")?;
+
+    let minlon = attributes
+        .iter()
+        .filter(|attr| attr.name.local_name == "minlon")
+        .nth(0)
+        .ok_or(ErrorKind::InvalidElementLacksAttribute("minlon", "bounds"))?;
+    let maxlon = attributes
+        .iter()
+        .filter(|attr| attr.name.local_name == "maxlon")
+        .nth(0)
+        .ok_or(ErrorKind::InvalidElementLacksAttribute("maxlon", "bounds"))?;
+
+    let minlon: f64 = minlon
+        .value
+        .parse()
+        .chain_err(|| "error while casting min longitude to f64")?;
+    let maxlon: f64 = maxlon
+        .value
+        .parse()
+        .chain_err(|| "error while casting max longitude to f64")?;
+
+    let bounds: Bbox<f64> = Bbox {
+        xmin: minlon,
+        xmax: maxlon,
+        ymin: minlat,
+        ymax: maxlat,
     };
+
     for event in context.reader() {
         match event.chain_err(|| "error while parsing XML")? {
-            XmlEvent::StartElement {
-                name, attributes, ..
-            } => {
-                ensure!(element.is_none(), "cannot start element inside bounds");
-                // get required bounds
-                let minlat = attributes
-                    .iter()
-                    .filter(|attr| attr.name.local_name == "minlat")
-                    .nth(0)
-                    .ok_or("no min latitude attribute on bounds tag".to_owned())?;
-                let maxlat = attributes
-                    .iter()
-                    .filter(|attr| attr.name.local_name == "maxlat")
-                    .nth(0)
-                    .ok_or("no max latitude attribute on bounds tag".to_owned())?;
-
-                let minlat: f64 = minlat
-                    .value
-                    .parse()
-                    .chain_err(|| "error while casting min latitude to f64")?;
-                let maxlat: f64 = maxlat
-                    .value
-                    .parse()
-                    .chain_err(|| "error while casting max latitude to f64")?;
-
-                let minlon = attributes
-                    .iter()
-                    .filter(|attr| attr.name.local_name == "minlon")
-                    .nth(0)
-                    .ok_or("no min longitude attribute on bounds tag".to_owned())?;
-                let maxlon = attributes
-                    .iter()
-                    .filter(|attr| attr.name.local_name == "maxlon")
-                    .nth(0)
-                    .ok_or("no max longitude attribute on bounds tag".to_owned())?;
-
-                let minlon: f64 = minlon
-                    .value
-                    .parse()
-                    .chain_err(|| "error while casting min longitude to f64")?;
-                let maxlon: f64 = maxlon
-                    .value
-                    .parse()
-                    .chain_err(|| "error while casting max longitude to f64")?;
-
-                bounds.xmin = minlon;
-                bounds.xmax = maxlon;
-                bounds.ymin = minlat;
-                bounds.ymax = maxlat;
-
-                element = Some(name.local_name);
+            XmlEvent::StartElement { name, .. } => {
+                bail!(ErrorKind::InvalidChildElement(
+                    name.local_name.clone(),
+                    "bounds"
+                ));
             }
-
-            XmlEvent::EndElement { .. } => {
+            XmlEvent::EndElement { name } => {
+                ensure!(
+                    name.local_name == "bounds",
+                    ErrorKind::InvalidClosingTag(name.local_name.clone(), "bounds")
+                );
                 return Ok(bounds);
             }
-
             _ => {}
         }
     }
-
-    return Err("no end tag for bounds".into());
+    bail!(ErrorKind::MissingClosingTag("bounds"));
 }
 
 #[cfg(test)]

--- a/src/parser/bounds.rs
+++ b/src/parser/bounds.rs
@@ -82,10 +82,8 @@ pub fn consume<R: Read>(context: &mut Context<R>) -> Result<Bbox<f64>> {
 #[cfg(test)]
 mod tests {
     use std::io::BufReader;
-    use xml::reader::EventReader;
 
     use GpxVersion;
-    use parser::Context;
     use super::consume;
 
     #[test]

--- a/src/parser/email.rs
+++ b/src/parser/email.rs
@@ -54,10 +54,8 @@ pub fn consume<R: Read>(context: &mut Context<R>) -> Result<String> {
 #[cfg(test)]
 mod tests {
     use std::io::BufReader;
-    use xml::reader::EventReader;
 
     use GpxVersion;
-    use parser::Context;
     use super::consume;
 
     #[test]

--- a/src/parser/email.rs
+++ b/src/parser/email.rs
@@ -24,7 +24,10 @@ pub fn consume<R: Read>(context: &mut Context<R>) -> Result<String> {
                             .iter()
                             .filter(|attr| attr.name.local_name == "id")
                             .nth(0)
-                            .ok_or(Error::from(ErrorKind::InvalidElementLacksAttribute("id")))?;
+                            .ok_or(Error::from(ErrorKind::InvalidElementLacksAttribute(
+                                "id",
+                                "email",
+                            )))?;
 
                         let id = id.clone().value;
 
@@ -34,6 +37,7 @@ pub fn consume<R: Read>(context: &mut Context<R>) -> Result<String> {
                             .nth(0)
                             .ok_or(Error::from(ErrorKind::InvalidElementLacksAttribute(
                                 "domain",
+                                "email",
                             )))?;
 
                         let domain = domain.clone().value;
@@ -105,7 +109,7 @@ mod tests {
         );
         assert_eq!(
             err.to_string(),
-            "invalid element, lacks required attribute id"
+            "invalid element, email lacks required attribute id"
         );
     }
 
@@ -119,7 +123,7 @@ mod tests {
         );
         assert_eq!(
             err.to_string(),
-            "invalid element, lacks required attribute domain"
+            "invalid element, email lacks required attribute domain"
         );
     }
 

--- a/src/parser/email.rs
+++ b/src/parser/email.rs
@@ -4,8 +4,8 @@ use errors::*;
 use std::io::Read;
 use xml::reader::XmlEvent;
 
-use parser::Context;
 use parser::verify_starting_tag;
+use parser::Context;
 
 /// consume consumes a GPX email from the `reader` until it ends.
 /// When it returns, the reader will be at the element after the end GPX email
@@ -56,7 +56,6 @@ mod tests {
     use std::io::BufReader;
 
     use super::consume;
-    use parser::Context;
     use GpxVersion;
 
     #[test]

--- a/src/parser/extensions.rs
+++ b/src/parser/extensions.rs
@@ -41,7 +41,6 @@ mod tests {
     use std::io::BufReader;
 
     use super::consume;
-    use parser::Context;
     use GpxVersion;
 
     #[test]

--- a/src/parser/extensions.rs
+++ b/src/parser/extensions.rs
@@ -39,10 +39,8 @@ pub fn consume<R: Read>(context: &mut Context<R>) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use std::io::BufReader;
-    use xml::reader::EventReader;
 
     use GpxVersion;
-    use parser::Context;
     use super::consume;
 
     #[test]

--- a/src/parser/fix.rs
+++ b/src/parser/fix.rs
@@ -27,13 +27,11 @@ pub fn consume<R: Read>(context: &mut Context<R>) -> Result<Fix> {
 #[cfg(test)]
 mod tests {
     use std::io::BufReader;
-    use xml::reader::EventReader;
 
     use super::consume;
 
     use GpxVersion;
     use Fix;
-    use parser::Context;
 
     #[test]
     fn consume_fix() {

--- a/src/parser/fix.rs
+++ b/src/parser/fix.rs
@@ -10,7 +10,7 @@ use types::Fix;
 
 /// consume consumes an element as a fix.
 pub fn consume<R: Read>(context: &mut Context<R>) -> Result<Fix> {
-    let fix_string = string::consume(context)?;
+    let fix_string = string::consume(context, "fix")?;
 
     let fix = match fix_string.as_ref() {
         "none" => Fix::None,

--- a/src/parser/fix.rs
+++ b/src/parser/fix.rs
@@ -29,7 +29,7 @@ mod tests {
     use std::io::BufReader;
 
     use super::consume;
- 
+
     use Fix;
     use GpxVersion;
 

--- a/src/parser/gpx.rs
+++ b/src/parser/gpx.rs
@@ -11,9 +11,9 @@ use parser::metadata;
 use parser::string;
 use parser::time;
 use parser::track;
+use parser::verify_starting_tag;
 use parser::waypoint;
 use parser::Context;
-use parser::verify_starting_tag;
 
 use Gpx;
 use GpxVersion;
@@ -146,11 +146,8 @@ pub fn consume<R: Read>(context: &mut Context<R>) -> Result<Gpx> {
 mod tests {
     use geo::Point;
     use std::io::BufReader;
-    use geo::Point;
 
-    use GpxVersion;
     use super::consume;
-    use parser::Context;
     use GpxVersion;
 
     #[test]

--- a/src/parser/gpx.rs
+++ b/src/parser/gpx.rs
@@ -72,7 +72,7 @@ pub fn consume<R: Read>(context: &mut Context<R>) -> Result<Gpx> {
                     gpx.tracks.push(track::consume(context)?);
                 }
                 "wpt" => {
-                    gpx.waypoints.push(waypoint::consume(context)?);
+                    gpx.waypoints.push(waypoint::consume(context, "wpt")?);
                 }
                 "time" if context.version == GpxVersion::Gpx10 => {
                     time = Some(time::consume(context)?);

--- a/src/parser/gpx.rs
+++ b/src/parser/gpx.rs
@@ -190,7 +190,6 @@ mod tests {
             GpxVersion::Unknown
         );
 
-        println!("########################### {:?}", gpx);
         assert!(gpx.is_ok());
         let gpx = gpx.unwrap();
 

--- a/src/parser/gpx.rs
+++ b/src/parser/gpx.rs
@@ -145,11 +145,9 @@ pub fn consume<R: Read>(context: &mut Context<R>) -> Result<Gpx> {
 #[cfg(test)]
 mod tests {
     use std::io::BufReader;
-    use xml::reader::EventReader;
     use geo::Point;
 
     use GpxVersion;
-    use parser::Context;
     use super::consume;
 
     #[test]

--- a/src/parser/gpx.rs
+++ b/src/parser/gpx.rs
@@ -81,25 +81,25 @@ pub fn consume<R: Read>(context: &mut Context<R>) -> Result<Gpx> {
                     bounds = Some(bounds::consume(context)?);
                 }
                 "author" if context.version == GpxVersion::Gpx10 => {
-                    author = Some(string::consume(context)?);
+                    author = Some(string::consume(context, "author")?);
                 }
                 "email" if context.version == GpxVersion::Gpx10 => {
-                    email = Some(string::consume(context)?);
+                    email = Some(string::consume(context, "email")?);
                 }
                 "url" if context.version == GpxVersion::Gpx10 => {
-                    url = Some(string::consume(context)?);
+                    url = Some(string::consume(context, "url")?);
                 }
                 "urlname" if context.version == GpxVersion::Gpx10 => {
-                    urlname = Some(string::consume(context)?);
+                    urlname = Some(string::consume(context, "urlname")?);
                 }
                 "name" if context.version == GpxVersion::Gpx10 => {
-                    gpx_name = Some(string::consume(context)?);
+                    gpx_name = Some(string::consume(context, "name")?);
                 }
                 "description" if context.version == GpxVersion::Gpx10 => {
-                    description = Some(string::consume(context)?);
+                    description = Some(string::consume(context, "description")?);
                 }
                 "keywords" if context.version == GpxVersion::Gpx10 => {
-                    keywords = Some(string::consume(context)?);
+                    keywords = Some(string::consume(context, "keywords")?);
                 }
                 child => {
                     bail!(ErrorKind::InvalidChildElement(String::from(child), "gpx"));

--- a/src/parser/gpx.rs
+++ b/src/parser/gpx.rs
@@ -90,6 +90,7 @@ pub fn consume<R: Read>(context: &mut Context<R>) -> Result<Gpx> {
                             } else {
                                 Err(Error::from(ErrorKind::InvalidElementLacksAttribute(
                                     "version",
+                                    "gpx",
                                 )))
                             }
                         }

--- a/src/parser/gpx.rs
+++ b/src/parser/gpx.rs
@@ -13,29 +13,13 @@ use parser::track;
 use parser::metadata;
 use parser::waypoint;
 use parser::Context;
+use parser::verify_starting_tag;
 
 use Gpx;
 use GpxVersion;
 use Link;
 use Person;
 use Metadata;
-
-enum ParseEvent {
-    StartAuthor,      // GPX 1.0
-    StartBounds,      // GPX 1.0
-    StartDescription, // GPX 1.0
-    StartEmail,       // GPX 1.0
-    StartKeywords,    // GPX 1.0
-    StartMetadata,
-    StartName, // GPX 1.0
-    StartTime, // GPX 1.0
-    StartTrack,
-    StartUrl,     // GPX 1.0
-    StartUrlname, // GPX 1.0
-    StartWaypoint,
-    Ignore,
-    EndGpx,
-}
 
 /// Convert the version string to the version enum
 fn version_string_to_version(version_str: &str) -> Result<GpxVersion> {
@@ -56,137 +40,79 @@ pub fn consume<R: Read>(context: &mut Context<R>) -> Result<Gpx> {
     let mut email: Option<String> = None;
     let mut time: Option<DateTime<Utc>> = None;
     let mut bounds: Option<Bbox<f64>> = None;
-    let mut name: Option<String> = None;
+    let mut gpx_name: Option<String> = None;
     let mut description: Option<String> = None;
     let mut keywords: Option<String> = None;
 
+    // First we consume the gpx tag and its attributes
+    let attributes = verify_starting_tag(context, "gpx")?;
+    let version = attributes
+        .iter()
+        .filter(|attr| attr.name.local_name == "version")
+        .nth(0)
+        .ok_or(ErrorKind::InvalidElementLacksAttribute("version", "gpx"))?;
+    gpx.version = version_string_to_version(&version.value)?;
+    context.version = gpx.version;
+
     loop {
-        // Peep into the reader and see what type of event is next. Based on
-        // that information, we'll either forward the event to a downstream
-        // module or take the information for ourselves.
-        let event: Result<ParseEvent> = {
+        let next_event = {
             if let Some(next) = context.reader.peek() {
-                match next {
-                    &Ok(XmlEvent::StartElement {
-                        ref name,
-                        ref attributes,
-                        ..
-                    }) => match name.local_name.as_ref() {
-                        "metadata" if context.version != GpxVersion::Gpx10 => {
-                            Ok(ParseEvent::StartMetadata)
-                        }
-                        "trk" => Ok(ParseEvent::StartTrack),
-                        "wpt" => Ok(ParseEvent::StartWaypoint),
-                        "gpx" => {
-                            if let Ok(version) = attributes
-                                .iter()
-                                .filter(|attr| attr.name.local_name == "version")
-                                .nth(0)
-                                .ok_or("no version found".to_owned())
-                            {
-                                gpx.version = version_string_to_version(&version.value)?;
-                                context.version = gpx.version;
-                                Ok(ParseEvent::Ignore)
-                            } else {
-                                Err(Error::from(ErrorKind::InvalidElementLacksAttribute(
-                                    "version",
-                                    "gpx",
-                                )))
-                            }
-                        }
-                        "time" if context.version == GpxVersion::Gpx10 => Ok(ParseEvent::StartTime),
-                        "bounds" if context.version == GpxVersion::Gpx10 => {
-                            Ok(ParseEvent::StartBounds)
-                        }
-                        "author" if context.version == GpxVersion::Gpx10 => {
-                            Ok(ParseEvent::StartAuthor)
-                        }
-                        "email" if context.version == GpxVersion::Gpx10 => {
-                            Ok(ParseEvent::StartEmail)
-                        }
-                        "url" if context.version == GpxVersion::Gpx10 => Ok(ParseEvent::StartUrl),
-                        "urlname" if context.version == GpxVersion::Gpx10 => {
-                            Ok(ParseEvent::StartUrlname)
-                        }
-                        "name" if context.version == GpxVersion::Gpx10 => Ok(ParseEvent::StartName),
-                        "description" if context.version == GpxVersion::Gpx10 => {
-                            Ok(ParseEvent::StartDescription)
-                        }
-                        "keywords" if context.version == GpxVersion::Gpx10 => {
-                            Ok(ParseEvent::StartKeywords)
-                        }
-                        child => Err(Error::from(ErrorKind::InvalidChildElement(
-                            String::from(child),
-                            "gpx",
-                        )))?,
-                    },
-
-                    &Ok(XmlEvent::EndElement { .. }) => Ok(ParseEvent::EndGpx),
-
-                    _ => Ok(ParseEvent::Ignore),
-                }
+                next.clone()
             } else {
                 break;
             }
         };
 
-        match event.chain_err(|| Error::from("error while parsing gpx event"))? {
-            ParseEvent::Ignore => {
-                context.reader.next();
-            }
-
-            ParseEvent::StartAuthor => {
-                author = Some(string::consume(context)?);
-            }
-
-            ParseEvent::StartBounds => {
-                bounds = Some(bounds::consume(context)?);
-            }
-
-            ParseEvent::StartEmail => {
-                email = Some(string::consume(context)?);
-            }
-
-            ParseEvent::StartMetadata => {
-                gpx.metadata = Some(metadata::consume(context)?);
-            }
-
-            ParseEvent::StartName => {
-                name = Some(string::consume(context)?);
-            }
-
-            ParseEvent::StartTime => {
-                time = Some(time::consume(context)?);
-            }
-
-            ParseEvent::StartUrl => {
-                url = Some(string::consume(context)?);
-            }
-
-            ParseEvent::StartUrlname => {
-                urlname = Some(string::consume(context)?);
-            }
-
-            ParseEvent::StartDescription => {
-                description = Some(string::consume(context)?);
-            }
-
-            ParseEvent::StartKeywords => {
-                keywords = Some(string::consume(context)?);
-            }
-
-            ParseEvent::StartTrack => {
-                gpx.tracks.push(track::consume(context)?);
-            }
-
-            ParseEvent::StartWaypoint => {
-                gpx.waypoints.push(waypoint::consume(context)?);
-            }
-
-            ParseEvent::EndGpx => {
+        match next_event.chain_err(|| Error::from("error while parsing gpx event"))? {
+            XmlEvent::StartElement { ref name, .. } => match name.local_name.as_ref() {
+                "metadata" if context.version != GpxVersion::Gpx10 => {
+                    gpx.metadata = Some(metadata::consume(context)?);
+                }
+                "trk" => {
+                    gpx.tracks.push(track::consume(context)?);
+                }
+                "wpt" => {
+                    gpx.waypoints.push(waypoint::consume(context)?);
+                }
+                "time" if context.version == GpxVersion::Gpx10 => {
+                    time = Some(time::consume(context)?);
+                }
+                "bounds" if context.version == GpxVersion::Gpx10 => {
+                    bounds = Some(bounds::consume(context)?);
+                }
+                "author" if context.version == GpxVersion::Gpx10 => {
+                    author = Some(string::consume(context)?);
+                }
+                "email" if context.version == GpxVersion::Gpx10 => {
+                    email = Some(string::consume(context)?);
+                }
+                "url" if context.version == GpxVersion::Gpx10 => {
+                    url = Some(string::consume(context)?);
+                }
+                "urlname" if context.version == GpxVersion::Gpx10 => {
+                    urlname = Some(string::consume(context)?);
+                }
+                "name" if context.version == GpxVersion::Gpx10 => {
+                    gpx_name = Some(string::consume(context)?);
+                }
+                "description" if context.version == GpxVersion::Gpx10 => {
+                    description = Some(string::consume(context)?);
+                }
+                "keywords" if context.version == GpxVersion::Gpx10 => {
+                    keywords = Some(string::consume(context)?);
+                }
+                child => {
+                    bail!(ErrorKind::InvalidChildElement(String::from(child), "gpx"));
+                }
+            },
+            XmlEvent::EndElement { name } => {
+                ensure!(
+                    name.local_name == "gpx",
+                    ErrorKind::InvalidClosingTag(name.local_name.clone(), "gpx")
+                );
                 if gpx.version == GpxVersion::Gpx10 {
                     let mut metadata: Metadata = Default::default();
-                    metadata.name = name;
+                    metadata.name = gpx_name;
                     metadata.time = time;
                     metadata.bounds = bounds;
                     let mut person: Person = Default::default();
@@ -207,10 +133,13 @@ pub fn consume<R: Read>(context: &mut Context<R>) -> Result<Gpx> {
 
                 return Ok(gpx);
             }
+            _ => {
+                context.reader.next(); //consume and ignore this event
+            }
         }
     }
 
-    return Err("no end tag for gpx".into());
+    bail!(ErrorKind::MissingClosingTag("gpx"));
 }
 
 #[cfg(test)]
@@ -261,6 +190,7 @@ mod tests {
             GpxVersion::Unknown
         );
 
+        println!("########################### {:?}", gpx);
         assert!(gpx.is_ok());
         let gpx = gpx.unwrap();
 

--- a/src/parser/link.rs
+++ b/src/parser/link.rs
@@ -62,9 +62,6 @@ pub fn consume<R: Read>(context: &mut Context<R>) -> Result<Link> {
 #[cfg(test)]
 mod tests {
     use std::io::BufReader;
-    use xml::reader::EventReader;
-
-    use parser::Context;
 
     use GpxVersion;
     use super::consume;

--- a/src/parser/link.rs
+++ b/src/parser/link.rs
@@ -6,6 +6,7 @@ use xml::reader::XmlEvent;
 
 use parser::string;
 use parser::Context;
+use parser::verify_starting_tag;
 
 use Link;
 
@@ -14,42 +15,48 @@ use Link;
 /// tag.
 pub fn consume<R: Read>(context: &mut Context<R>) -> Result<Link> {
     let mut link: Link = Default::default();
+    let attributes = verify_starting_tag(context, "link")?;
+    let attr = attributes
+        .into_iter()
+        .filter(|attr| attr.name.local_name == "href")
+        .nth(0);
 
-    while let Some(event) = context.reader.next() {
-        match event.chain_err(|| "error while parsing XML")? {
-            XmlEvent::StartElement {
-                name, attributes, ..
-            } => {
-                match name.local_name.as_ref() {
-                    "text" => link.text = Some(string::consume(context)?),
-                    "type" => link._type = Some(string::consume(context)?),
-                    "link" => {
-                        // retrieve mandatory href attribute
-                        let attr = attributes
-                            .into_iter()
-                            .filter(|attr| attr.name.local_name == "href")
-                            .nth(0);
+    let attr = attr.ok_or(ErrorKind::InvalidElementLacksAttribute("href", "link"))?;
 
-                        let attr = attr.ok_or("no href attribute on link tag".to_owned())?;
+    link.href = attr.value;
 
-                        link.href = attr.value;
-                    }
-                    child => Err(Error::from(ErrorKind::InvalidChildElement(
-                        String::from(child),
-                        "link",
-                    )))?,
-                }
+    loop {
+        let next_event = {
+            if let Some(next) = context.reader.peek() {
+                next.clone()
+            } else {
+                break;
             }
+        };
 
-            XmlEvent::EndElement { .. } => {
+        match next_event.chain_err(|| Error::from("error while parsing link event"))? {
+            XmlEvent::StartElement { ref name, .. } => match name.local_name.as_ref() {
+                "text" => link.text = Some(string::consume(context)?),
+                "type" => link._type = Some(string::consume(context)?),
+                child => {
+                    bail!(ErrorKind::InvalidChildElement(String::from(child), "link"));
+                }
+            },
+            XmlEvent::EndElement { ref name } => {
+                ensure!(
+                    name.local_name == "link",
+                    ErrorKind::InvalidClosingTag(name.local_name.clone(), "link")
+                );
+                context.reader.next();
                 return Ok(link);
             }
-
-            _ => {}
+            _ => {
+                context.reader.next(); //consume and ignore this event
+            }
         }
     }
 
-    return Err("no end tag for link".into());
+    bail!(ErrorKind::MissingClosingTag("link"));
 }
 
 #[cfg(test)]

--- a/src/parser/link.rs
+++ b/src/parser/link.rs
@@ -5,8 +5,8 @@ use std::io::Read;
 use xml::reader::XmlEvent;
 
 use parser::string;
-use parser::Context;
 use parser::verify_starting_tag;
+use parser::Context;
 
 use Link;
 

--- a/src/parser/link.rs
+++ b/src/parser/link.rs
@@ -36,8 +36,8 @@ pub fn consume<R: Read>(context: &mut Context<R>) -> Result<Link> {
 
         match next_event.chain_err(|| Error::from("error while parsing link event"))? {
             XmlEvent::StartElement { ref name, .. } => match name.local_name.as_ref() {
-                "text" => link.text = Some(string::consume(context)?),
-                "type" => link._type = Some(string::consume(context)?),
+                "text" => link.text = Some(string::consume(context, "text")?),
+                "type" => link._type = Some(string::consume(context, "type")?),
                 child => {
                     bail!(ErrorKind::InvalidChildElement(String::from(child), "link"));
                 }

--- a/src/parser/metadata.rs
+++ b/src/parser/metadata.rs
@@ -77,11 +77,9 @@ pub fn consume<R: Read>(context: &mut Context<R>) -> Result<Metadata> {
 #[cfg(test)]
 mod tests {
     use std::io::BufReader;
-    use xml::reader::EventReader;
     use chrono::prelude::*;
 
     use GpxVersion;
-    use parser::Context;
     use super::consume;
 
     #[test]

--- a/src/parser/metadata.rs
+++ b/src/parser/metadata.rs
@@ -10,99 +10,68 @@ use parser::person;
 use parser::time;
 use parser::bounds;
 use parser::Context;
+use parser::verify_starting_tag;
 
 use Metadata;
 
-enum ParseEvent {
-    StartName,
-    StartDescription,
-    StartAuthor,
-    StartKeywords,
-    StartTime,
-    StartLink,
-    StartBounds,
-    Ignore,
-    EndMetadata,
-}
-
 pub fn consume<R: Read>(context: &mut Context<R>) -> Result<Metadata> {
     let mut metadata: Metadata = Default::default();
+    verify_starting_tag(context, "metadata")?;
 
     loop {
-        // Peep into the reader and see what type of event is next. Based on
-        // that information, we'll either forward the event to a downstream
-        // module or take the information for ourselves.
-        let event: Result<ParseEvent> = {
+        let next_event = {
             if let Some(next) = context.reader.peek() {
-                match next {
-                    &Ok(XmlEvent::StartElement { ref name, .. }) => {
-                        match name.local_name.as_ref() {
-                            "metadata" => Ok(ParseEvent::Ignore),
-                            "name" => Ok(ParseEvent::StartName),
-                            "description" => Ok(ParseEvent::StartDescription),
-                            "author" => Ok(ParseEvent::StartAuthor),
-                            "keywords" => Ok(ParseEvent::StartKeywords),
-                            "time" => Ok(ParseEvent::StartTime),
-                            "link" => Ok(ParseEvent::StartLink),
-                            "bounds" => Ok(ParseEvent::StartBounds),
-                            child => Err(Error::from(ErrorKind::InvalidChildElement(
-                                String::from(child),
-                                "metadata",
-                            )))?,
-                        }
-                    }
-
-                    &Ok(XmlEvent::EndElement { .. }) => Ok(ParseEvent::EndMetadata),
-
-                    _ => Ok(ParseEvent::Ignore),
-                }
+                next.clone()
             } else {
                 break;
             }
         };
 
-        match event.chain_err(|| Error::from("error while parsing gpx event"))? {
-            ParseEvent::Ignore => {
-                context.reader.next();
-            }
-
-            ParseEvent::StartName => {
-                metadata.name = Some(string::consume(context)?);
-            }
-
-            ParseEvent::StartDescription => {
-                metadata.description = Some(string::consume(context)?);
-            }
-
-            ParseEvent::StartAuthor => {
-                metadata.author = Some(person::consume(context)?);
-            }
-
-            ParseEvent::StartKeywords => {
-                metadata.keywords = Some(string::consume(context)?);
-            }
-
-            ParseEvent::StartTime => {
-                metadata.time = Some(time::consume(context)?);
-            }
-
-            ParseEvent::StartLink => {
-                metadata.links.push(link::consume(context)?);
-            }
-
-            ParseEvent::StartBounds => {
-                metadata.bounds = Some(bounds::consume(context)?);
-            }
-
-            ParseEvent::EndMetadata => {
-                context.reader.next();
-
+        match next_event.chain_err(|| Error::from("error while parsing metadata event"))? {
+            XmlEvent::StartElement { ref name, .. } => match name.local_name.as_ref() {
+                "name" => {
+                    metadata.name = Some(string::consume(context)?);
+                }
+                "description" => {
+                    metadata.description = Some(string::consume(context)?);
+                }
+                "author" => {
+                    metadata.author = Some(person::consume(context)?);
+                }
+                "keywords" => {
+                    metadata.keywords = Some(string::consume(context)?);
+                }
+                "time" => {
+                    metadata.time = Some(time::consume(context)?);
+                }
+                "link" => {
+                    metadata.links.push(link::consume(context)?);
+                }
+                "bounds" => {
+                    metadata.bounds = Some(bounds::consume(context)?);
+                }
+                child => {
+                    bail!(ErrorKind::InvalidChildElement(
+                        String::from(child),
+                        "metadata"
+                    ));
+                }
+            },
+            XmlEvent::EndElement { ref name } => {
+                ensure!(
+                    name.local_name == "metadata",
+                    ErrorKind::InvalidClosingTag(name.local_name.clone(), "metadata")
+                );
+                context.reader.next(); //consume the end tag
                 return Ok(metadata);
+            }
+            _ => {
+                context.reader.next(); //consume and ignore this event
             }
         }
     }
 
-    return Err("no end tag for metadata".into());
+    bail!(ErrorKind::MissingClosingTag("metadata"));
 }
 
 #[cfg(test)]

--- a/src/parser/metadata.rs
+++ b/src/parser/metadata.rs
@@ -36,7 +36,7 @@ pub fn consume<R: Read>(context: &mut Context<R>) -> Result<Metadata> {
                     metadata.description = Some(string::consume(context)?);
                 }
                 "author" => {
-                    metadata.author = Some(person::consume(context)?);
+                    metadata.author = Some(person::consume(context, "author")?);
                 }
                 "keywords" => {
                     metadata.keywords = Some(string::consume(context)?);

--- a/src/parser/metadata.rs
+++ b/src/parser/metadata.rs
@@ -30,16 +30,16 @@ pub fn consume<R: Read>(context: &mut Context<R>) -> Result<Metadata> {
         match next_event.chain_err(|| Error::from("error while parsing metadata event"))? {
             XmlEvent::StartElement { ref name, .. } => match name.local_name.as_ref() {
                 "name" => {
-                    metadata.name = Some(string::consume(context)?);
+                    metadata.name = Some(string::consume(context, "name")?);
                 }
                 "description" => {
-                    metadata.description = Some(string::consume(context)?);
+                    metadata.description = Some(string::consume(context, "description")?);
                 }
                 "author" => {
                     metadata.author = Some(person::consume(context, "author")?);
                 }
                 "keywords" => {
-                    metadata.keywords = Some(string::consume(context)?);
+                    metadata.keywords = Some(string::consume(context, "keywords")?);
                 }
                 "time" => {
                     metadata.time = Some(time::consume(context)?);

--- a/src/parser/metadata.rs
+++ b/src/parser/metadata.rs
@@ -9,8 +9,8 @@ use parser::link;
 use parser::person;
 use parser::string;
 use parser::time;
-use parser::Context;
 use parser::verify_starting_tag;
+use parser::Context;
 
 use Metadata;
 
@@ -78,11 +78,8 @@ pub fn consume<R: Read>(context: &mut Context<R>) -> Result<Metadata> {
 mod tests {
     use chrono::prelude::*;
     use std::io::BufReader;
-    use chrono::prelude::*;
 
-    use GpxVersion;
     use super::consume;
-    use parser::Context;
     use GpxVersion;
 
     #[test]

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -57,7 +57,6 @@ pub fn verify_starting_tag<R: Read>(
     //we ignore and skip all xmlevents except StartElement, Characters and EndElement
     loop {
         let next = context.reader.next();
-        println!("{:?}", next);
         match next {
             Some(Ok(XmlEvent::StartElement {
                 name, attributes, ..

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -10,6 +10,12 @@ macro_rules! consume {
         let mut context = Context::new(events, $version);
         consume(&mut context)
     }};
+    ($xml: expr, $version: expr, $tagname: expr) => {{
+        let reader = BufReader::new($xml.as_bytes());
+        let events = EventReader::new(reader).into_iter().peekable();
+        let mut context = Context::new(events, $version);
+        consume(&mut context, $tagname)
+    }};
 }
 
 pub mod bounds;

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -4,14 +4,14 @@
 #[cfg(test)]
 #[macro_export]
 macro_rules! consume {
-    ($xml: expr, $version: expr) => {{
+    ($xml:expr, $version:expr) => {{
         use parser::create_context;
         consume(&mut create_context(
             BufReader::new($xml.as_bytes()),
             $version,
         ))
     }};
-    ($xml: expr, $version: expr, $tagname: expr) => {{
+    ($xml:expr, $version:expr, $tagname:expr) => {{
         use parser::create_context;
         consume(
             &mut create_context(BufReader::new($xml.as_bytes()), $version),
@@ -37,13 +37,12 @@ pub mod waypoint;
 use errors::*;
 use std::io::Read;
 use std::iter::Peekable;
-use xml::EventReader;
-use xml::ParserConfig;
+use types::GpxVersion;
+use xml::attribute::OwnedAttribute;
 use xml::reader::Events;
 use xml::reader::XmlEvent;
-use xml::attribute::OwnedAttribute;
-use types::GpxVersion;
-use xml::reader::Events;
+use xml::EventReader;
+use xml::ParserConfig;
 
 pub struct Context<R: Read> {
     reader: Peekable<Events<R>>,

--- a/src/parser/person.rs
+++ b/src/parser/person.rs
@@ -27,7 +27,7 @@ pub fn consume<R: Read>(context: &mut Context<R>, tagname: &'static str) -> Resu
 
         match next_event.chain_err(|| Error::from("error while parsing person event"))? {
             XmlEvent::StartElement { ref name, .. } => match name.local_name.as_ref() {
-                "name" => person.name = Some(string::consume(context)?),
+                "name" => person.name = Some(string::consume(context, "name")?),
                 "email" => person.email = Some(email::consume(context)?),
                 "link" => person.link = Some(link::consume(context)?),
                 child => {

--- a/src/parser/person.rs
+++ b/src/parser/person.rs
@@ -8,76 +8,50 @@ use parser::email;
 use parser::link;
 use parser::string;
 use parser::Context;
+use parser::verify_starting_tag;
 
 use Person;
 
-enum ParseEvent {
-    StartName,
-    StartEmail,
-    StartLink,
-    EndPerson,
-    Ignore,
-}
-
-pub fn consume<R: Read>(context: &mut Context<R>) -> Result<Person> {
+pub fn consume<R: Read>(context: &mut Context<R>, tagname: &'static str) -> Result<Person> {
     let mut person: Person = Default::default();
+    verify_starting_tag(context, tagname)?;
 
     loop {
-        // Peep into the reader and see what type of event is next. Based on
-        // that information, we'll either forward the event to a downstream
-        // module or take the information for ourselves.
-        let event: Result<ParseEvent> = {
+        let next_event = {
             if let Some(next) = context.reader.peek() {
-                match next {
-                    &Ok(XmlEvent::StartElement { ref name, .. }) => {
-                        match name.local_name.as_ref() {
-                            "name" => Ok(ParseEvent::StartName),
-                            "email" => Ok(ParseEvent::StartEmail),
-                            "link" => Ok(ParseEvent::StartLink),
-                            "person" => Ok(ParseEvent::Ignore),
-                            "author" => Ok(ParseEvent::Ignore),
-                            child => Err(Error::from(ErrorKind::InvalidChildElement(
-                                String::from(child),
-                                "person",
-                            ))),
-                        }
-                    }
-
-                    &Ok(XmlEvent::EndElement { .. }) => Ok(ParseEvent::EndPerson),
-
-                    _ => Ok(ParseEvent::Ignore),
-                }
+                next.clone()
             } else {
                 break;
             }
         };
 
-        match event.chain_err(|| Error::from("error while parsing person event"))? {
-            ParseEvent::Ignore => {
-                context.reader.next();
-            }
-
-            ParseEvent::StartName => {
-                person.name = Some(string::consume(context)?);
-            }
-
-            ParseEvent::StartEmail => {
-                person.email = Some(email::consume(context)?);
-            }
-
-            ParseEvent::StartLink => {
-                person.link = Some(link::consume(context)?);
-            }
-
-            ParseEvent::EndPerson => {
-                context.reader.next();
-
+        match next_event.chain_err(|| Error::from("error while parsing person event"))? {
+            XmlEvent::StartElement { ref name, .. } => match name.local_name.as_ref() {
+                "name" => person.name = Some(string::consume(context)?),
+                "email" => person.email = Some(email::consume(context)?),
+                "link" => person.link = Some(link::consume(context)?),
+                child => {
+                    bail!(ErrorKind::InvalidChildElement(
+                        String::from(child),
+                        "person"
+                    ));
+                }
+            },
+            XmlEvent::EndElement { ref name } => {
+                ensure!(
+                    name.local_name == tagname,
+                    ErrorKind::InvalidClosingTag(name.local_name.clone(), "person")
+                );
+                context.reader.next(); //consume the end tag
                 return Ok(person);
+            }
+            _ => {
+                context.reader.next(); //consume and ignore this event
             }
         }
     }
 
-    unreachable!("should return by now");
+    bail!(ErrorKind::MissingClosingTag("person"));
 }
 
 #[cfg(test)]
@@ -101,8 +75,9 @@ mod tests {
                         <type>some type</type>
                     </link>
                 </person>
-                ",
-            GpxVersion::Gpx11
+            ",
+            GpxVersion::Gpx11,
+            "person"
         );
 
         assert!(result.is_ok());

--- a/src/parser/person.rs
+++ b/src/parser/person.rs
@@ -7,8 +7,8 @@ use xml::reader::XmlEvent;
 use parser::email;
 use parser::link;
 use parser::string;
-use parser::Context;
 use parser::verify_starting_tag;
+use parser::Context;
 
 use Person;
 
@@ -58,9 +58,8 @@ pub fn consume<R: Read>(context: &mut Context<R>, tagname: &'static str) -> Resu
 mod tests {
     use std::io::BufReader;
 
-    use GpxVersion;
     use super::consume;
-    use parser::Context;
+    use GpxVersion;
 
     #[test]
     fn consume_whole_person() {

--- a/src/parser/person.rs
+++ b/src/parser/person.rs
@@ -57,10 +57,8 @@ pub fn consume<R: Read>(context: &mut Context<R>, tagname: &'static str) -> Resu
 #[cfg(test)]
 mod tests {
     use std::io::BufReader;
-    use xml::reader::EventReader;
 
     use GpxVersion;
-    use parser::Context;
     use super::consume;
 
     #[test]

--- a/src/parser/string.rs
+++ b/src/parser/string.rs
@@ -37,10 +37,8 @@ pub fn consume<R: Read>(context: &mut Context<R>, tagname: &'static str) -> Resu
 #[cfg(test)]
 mod tests {
     use std::io::BufReader;
-    use xml::reader::EventReader;
 
     use GpxVersion;
-    use parser::Context;
     use super::consume;
 
     #[test]

--- a/src/parser/string.rs
+++ b/src/parser/string.rs
@@ -5,31 +5,33 @@ use std::io::Read;
 use xml::reader::XmlEvent;
 
 use parser::Context;
+use parser::verify_starting_tag;
 
 /// consume consumes a single string as tag content.
-pub fn consume<R: Read>(context: &mut Context<R>) -> Result<String> {
-    let mut element: Option<String> = None;
+pub fn consume<R: Read>(context: &mut Context<R>, tagname: &'static str) -> Result<String> {
     let mut string: Option<String> = None;
+    verify_starting_tag(context, tagname)?;
 
     for event in context.reader() {
         match event.chain_err(|| "error while parsing XML")? {
-            XmlEvent::StartElement { name, .. } => {
-                ensure!(element.is_none(), "cannot start element inside string");
-
-                element = Some(name.local_name);
+            XmlEvent::StartElement { ref name, .. } => {
+                bail!(ErrorKind::InvalidChildElement(
+                    name.local_name.clone(),
+                    tagname
+                ));
             }
-
             XmlEvent::Characters(content) => string = Some(content),
-
-            XmlEvent::EndElement { .. } => {
+            XmlEvent::EndElement { ref name } => {
+                ensure!(
+                    name.local_name == tagname,
+                    ErrorKind::InvalidClosingTag(name.local_name.clone(), tagname)
+                );
                 return string.ok_or("no content inside string".into());
             }
-
             _ => {}
         }
     }
-
-    return Err("no end tag for string".into());
+    bail!(ErrorKind::MissingClosingTag(tagname));
 }
 
 #[cfg(test)]
@@ -43,7 +45,7 @@ mod tests {
 
     #[test]
     fn consume_simple_string() {
-        let result = consume!("<string>hello world</string>", GpxVersion::Gpx11);
+        let result = consume!("<string>hello world</string>", GpxVersion::Gpx11, "string");
 
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), "hello world");
@@ -52,7 +54,7 @@ mod tests {
     #[test]
     fn consume_new_tag() {
         // cannot start new tag inside string
-        let result = consume!("<foo>bar<baz></baz></foo>", GpxVersion::Gpx11);
+        let result = consume!("<foo>bar<baz></baz></foo>", GpxVersion::Gpx11, "foo");
 
         assert!(result.is_err());
     }
@@ -60,7 +62,7 @@ mod tests {
     #[test]
     fn consume_start_tag() {
         // must have starting tag
-        let result = consume!("bar</foo>", GpxVersion::Gpx11);
+        let result = consume!("bar</foo>", GpxVersion::Gpx11, "foo");
 
         assert!(result.is_err());
     }
@@ -68,7 +70,7 @@ mod tests {
     #[test]
     fn consume_end_tag() {
         // must have ending tag
-        let result = consume!("<foo>bar", GpxVersion::Gpx11);
+        let result = consume!("<foo>bar", GpxVersion::Gpx11, "foo");
 
         assert!(result.is_err());
     }
@@ -76,7 +78,7 @@ mod tests {
     #[test]
     fn consume_no_body() {
         // must have string content
-        let result = consume!("<foo></foo>", GpxVersion::Gpx11);
+        let result = consume!("<foo></foo>", GpxVersion::Gpx11, "foo");
 
         assert!(result.is_err());
     }
@@ -84,7 +86,7 @@ mod tests {
     #[test]
     fn consume_different_ending_tag() {
         // this is just illegal
-        let result = consume!("<foo></foobar>", GpxVersion::Gpx11);
+        let result = consume!("<foo></foobar>", GpxVersion::Gpx11, "foo");
 
         assert!(result.is_err());
     }

--- a/src/parser/string.rs
+++ b/src/parser/string.rs
@@ -4,8 +4,8 @@ use errors::*;
 use std::io::Read;
 use xml::reader::XmlEvent;
 
-use parser::Context;
 use parser::verify_starting_tag;
+use parser::Context;
 
 /// consume consumes a single string as tag content.
 pub fn consume<R: Read>(context: &mut Context<R>, tagname: &'static str) -> Result<String> {
@@ -39,7 +39,6 @@ mod tests {
     use std::io::BufReader;
 
     use super::consume;
-    use parser::Context;
     use GpxVersion;
 
     #[test]

--- a/src/parser/time.rs
+++ b/src/parser/time.rs
@@ -24,10 +24,8 @@ pub fn consume<R: Read>(context: &mut Context<R>) -> Result<DateTime<Utc>> {
 #[cfg(test)]
 mod tests {
     use std::io::BufReader;
-    use xml::reader::EventReader;
 
     use GpxVersion;
-    use parser::Context;
     use super::consume;
 
     #[test]

--- a/src/parser/time.rs
+++ b/src/parser/time.rs
@@ -13,7 +13,7 @@ use parser::Context;
 
 /// consume consumes an element as a time.
 pub fn consume<R: Read>(context: &mut Context<R>) -> Result<DateTime<Utc>> {
-    let time = string::consume(context)?;
+    let time = string::consume(context, "time")?;
 
     let time =
         DateTime::parse_from_rfc3339(&time).chain_err(|| "error while parsing time as RFC3339")?;

--- a/src/parser/time.rs
+++ b/src/parser/time.rs
@@ -25,7 +25,6 @@ mod tests {
     use std::io::BufReader;
 
     use super::consume;
-    use parser::Context;
     use GpxVersion;
 
     #[test]

--- a/src/parser/track.rs
+++ b/src/parser/track.rs
@@ -6,8 +6,8 @@ use xml::reader::XmlEvent;
 
 use parser::string;
 use parser::tracksegment;
-use parser::Context;
 use parser::verify_starting_tag;
+use parser::Context;
 
 use Track;
 
@@ -71,7 +71,6 @@ mod tests {
     use std::io::BufReader;
 
     use super::consume;
-    use parser::Context;
     use GpxVersion;
 
     #[test]

--- a/src/parser/track.rs
+++ b/src/parser/track.rs
@@ -28,19 +28,19 @@ pub fn consume<R: Read>(context: &mut Context<R>) -> Result<Track> {
         match next_event.chain_err(|| Error::from("error while parsing track event"))? {
             XmlEvent::StartElement { ref name, .. } => match name.local_name.as_ref() {
                 "name" => {
-                    track.name = Some(string::consume(context)?);
+                    track.name = Some(string::consume(context, "name")?);
                 }
                 "cmt" => {
-                    track.comment = Some(string::consume(context)?);
+                    track.comment = Some(string::consume(context, "cmt")?);
                 }
                 "desc" => {
-                    track.description = Some(string::consume(context)?);
+                    track.description = Some(string::consume(context, "desc")?);
                 }
                 "src" => {
-                    track.source = Some(string::consume(context)?);
+                    track.source = Some(string::consume(context, "src")?);
                 }
                 "type" => {
-                    track._type = Some(string::consume(context)?);
+                    track._type = Some(string::consume(context, "type")?);
                 }
                 "trkseg" => {
                     track.segments.push(tracksegment::consume(context)?);

--- a/src/parser/track.rs
+++ b/src/parser/track.rs
@@ -69,10 +69,8 @@ pub fn consume<R: Read>(context: &mut Context<R>) -> Result<Track> {
 #[cfg(test)]
 mod tests {
     use std::io::BufReader;
-    use xml::reader::EventReader;
 
     use GpxVersion;
-    use parser::Context;
     use super::consume;
 
     #[test]

--- a/src/parser/tracksegment.rs
+++ b/src/parser/tracksegment.rs
@@ -4,9 +4,9 @@ use errors::*;
 use std::io::Read;
 use xml::reader::XmlEvent;
 
+use parser::verify_starting_tag;
 use parser::waypoint;
 use parser::Context;
-use parser::verify_starting_tag;
 
 use TrackSegment;
 
@@ -55,11 +55,8 @@ pub fn consume<R: Read>(context: &mut Context<R>) -> Result<TrackSegment> {
 mod tests {
     use geo::length::Length;
     use std::io::BufReader;
-    use geo::length::Length;
 
-    use GpxVersion;
     use super::consume;
-    use parser::Context;
     use GpxVersion;
 
     #[test]

--- a/src/parser/tracksegment.rs
+++ b/src/parser/tracksegment.rs
@@ -53,7 +53,7 @@ pub fn consume<R: Read>(context: &mut Context<R>) -> Result<TrackSegment> {
             }
 
             TrackSegmentEvent::StartTrkPt => {
-                segment.points.push(waypoint::consume(context)?);
+                segment.points.push(waypoint::consume(context, "trkpt")?);
             }
 
             TrackSegmentEvent::EndTrkSeg => {

--- a/src/parser/tracksegment.rs
+++ b/src/parser/tracksegment.rs
@@ -54,11 +54,9 @@ pub fn consume<R: Read>(context: &mut Context<R>) -> Result<TrackSegment> {
 #[cfg(test)]
 mod tests {
     use std::io::BufReader;
-    use xml::reader::EventReader;
     use geo::length::Length;
 
     use GpxVersion;
-    use parser::Context;
     use super::consume;
 
     #[test]

--- a/src/parser/waypoint.rs
+++ b/src/parser/waypoint.rs
@@ -67,54 +67,54 @@ pub fn consume<R: Read>(context: &mut Context<R>, tagname: &'static str) -> Resu
             XmlEvent::StartElement { ref name, .. } => match name.local_name.as_ref() {
                 "ele" => {
                     // Cast the elevation to an f64, from a string.
-                    waypoint.elevation = Some(string::consume(context)?
+                    waypoint.elevation = Some(string::consume(context, "ele")?
                         .parse()
                         .chain_err(|| "error while casting elevation to f64")?)
                 }
                 "speed" if context.version == GpxVersion::Gpx10 => {
                     // Speed is from GPX 1.0
-                    waypoint.speed = Some(string::consume(context)?
+                    waypoint.speed = Some(string::consume(context, "speed")?
                         .parse()
                         .chain_err(|| "error while casting speed to f64")?);
                 }
                 "time" => waypoint.time = Some(time::consume(context)?),
-                "name" => waypoint.name = Some(string::consume(context)?),
-                "cmt" => waypoint.comment = Some(string::consume(context)?),
-                "desc" => waypoint.description = Some(string::consume(context)?),
-                "src" => waypoint.source = Some(string::consume(context)?),
+                "name" => waypoint.name = Some(string::consume(context, "name")?),
+                "cmt" => waypoint.comment = Some(string::consume(context, "cmt")?),
+                "desc" => waypoint.description = Some(string::consume(context, "desc")?),
+                "src" => waypoint.source = Some(string::consume(context, "src")?),
                 "link" => waypoint.links.push(link::consume(context)?),
-                "sym" => waypoint.symbol = Some(string::consume(context)?),
-                "type" => waypoint._type = Some(string::consume(context)?),
+                "sym" => waypoint.symbol = Some(string::consume(context, "sym")?),
+                "type" => waypoint._type = Some(string::consume(context, "type")?),
 
                 // Optional accuracy information
                 "fix" => waypoint.fix = Some(fix::consume(context)?),
                 "sat" => {
-                    waypoint.sat = Some(string::consume(context)?
+                    waypoint.sat = Some(string::consume(context, "sat")?
                         .parse()
                         .chain_err(|| "error while casting number of satellites (sat) to u64")?)
                 }
                 "hdop" => {
-                    waypoint.hdop = Some(string::consume(context)?.parse().chain_err(|| {
-                        "error while casting horizontal dilution of precision (hdop) to f64"
-                    })?)
+                    waypoint.hdop = Some(string::consume(context, "hdop")?.parse().chain_err(
+                        || "error while casting horizontal dilution of precision (hdop) to f64",
+                    )?)
                 }
                 "vdop" => {
-                    waypoint.vdop = Some(string::consume(context)?.parse().chain_err(|| {
-                        "error while casting vertical dilution of precision (vdop) to f64"
-                    })?)
+                    waypoint.vdop = Some(string::consume(context, "vdop")?.parse().chain_err(
+                        || "error while casting vertical dilution of precision (vdop) to f64",
+                    )?)
                 }
                 "pdop" => {
-                    waypoint.pdop = Some(string::consume(context)?.parse().chain_err(|| {
-                        "error while casting position dilution of precision (pdop) to f64"
-                    })?)
+                    waypoint.pdop = Some(string::consume(context, "pdop")?.parse().chain_err(
+                        || "error while casting position dilution of precision (pdop) to f64",
+                    )?)
                 }
                 "ageofgpsdata" => {
-                    waypoint.age = Some(string::consume(context)?
+                    waypoint.age = Some(string::consume(context, "ageofgpsdata")?
                         .parse()
                         .chain_err(|| "error while casting age of GPS data to f64")?)
                 }
                 "dgpsid" => {
-                    waypoint.dgpsid = Some(string::consume(context)?
+                    waypoint.dgpsid = Some(string::consume(context, "dgpsid")?
                         .parse()
                         .chain_err(|| "error while casting DGPS station ID to u16")?)
                 }

--- a/src/parser/waypoint.rs
+++ b/src/parser/waypoint.rs
@@ -148,12 +148,10 @@ pub fn consume<R: Read>(context: &mut Context<R>, tagname: &'static str) -> Resu
 #[cfg(test)]
 mod tests {
     use std::io::BufReader;
-    use xml::reader::EventReader;
     use geo::Point;
 
     use GpxVersion;
     use Fix;
-    use parser::Context;
     use super::consume;
 
     #[test]

--- a/src/parser/waypoint.rs
+++ b/src/parser/waypoint.rs
@@ -1,19 +1,17 @@
 //! waypoint handles parsing of GPX-spec waypoints.
 
-use chrono::prelude::*;
 use errors::*;
-use geo::Point;
 use std::io::Read;
 use xml::reader::XmlEvent;
-use geo::Point;
 
+use geo::Point;
 use parser::extensions;
 use parser::fix;
 use parser::link;
 use parser::string;
 use parser::time;
-use parser::Context;
 use parser::verify_starting_tag;
+use parser::Context;
 
 use Waypoint;
 
@@ -29,8 +27,7 @@ pub fn consume<R: Read>(context: &mut Context<R>, tagname: &'static str) -> Resu
         .filter(|attr| attr.name.local_name == "lat")
         .nth(0)
         .ok_or(ErrorKind::InvalidElementLacksAttribute(
-            "latitude",
-            "waypoint",
+            "latitude", "waypoint",
         ))?;
 
     let latitude: f64 = latitude
@@ -151,12 +148,8 @@ pub fn consume<R: Read>(context: &mut Context<R>, tagname: &'static str) -> Resu
 mod tests {
     use geo::Point;
     use std::io::BufReader;
-    use geo::Point;
 
-    use GpxVersion;
-    use Fix;
     use super::consume;
-    use parser::Context;
     use Fix;
     use GpxVersion;
 

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -3,9 +3,8 @@
 use std::io::Read;
 
 use errors::*;
-use xml::reader::EventReader;
 
-use parser::{gpx, Context};
+use parser::{create_context, gpx};
 use Gpx;
 use GpxVersion;
 
@@ -36,9 +35,5 @@ use GpxVersion;
 /// }
 /// ```
 pub fn read<R: Read>(reader: R) -> Result<Gpx> {
-    let parser = EventReader::new(reader);
-    let events = parser.into_iter().peekable();
-    let mut context = Context::new(events, GpxVersion::Unknown);
-
-    return gpx::consume(&mut context);
+    gpx::consume(&mut create_context(reader, GpxVersion::Unknown))
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -171,17 +171,15 @@ impl ToGeo<f64> for TrackSegment {
     }
 }
 
-// A Version of geo::Point that has the Default trait implemented
+// A Version of geo::Point that has the Default trait implemented, which
+// allows us to initialise the GpxPoint with default values compactly
+// in the Waypoint::new function below
 #[derive(Clone, Debug)]
-struct OurPoint {
-    point: Point<f64>,
-}
+struct GpxPoint(Point<f64>);
 
-impl Default for OurPoint {
-    fn default() -> OurPoint {
-        OurPoint {
-            point: Point::new(0 as f64, 0 as f64),
-        }
+impl Default for GpxPoint {
+    fn default() -> GpxPoint {
+        GpxPoint(Point::new(0 as f64, 0 as f64))
     }
 }
 
@@ -190,7 +188,7 @@ impl Default for OurPoint {
 #[derive(Clone, Default, Debug)]
 pub struct Waypoint {
     /// The geographical point.
-    point: OurPoint,
+    point: GpxPoint,
 
     /// Elevation (in meters) of the point.
     pub elevation: Option<f64>,
@@ -279,7 +277,7 @@ impl Waypoint {
     /// }
     /// ```
     pub fn point(&self) -> Point<f64> {
-        self.point.point
+        self.point.0 //.0 to extract the geo::Point from the tuple struct GpxPoint
     }
 
     /// Creates a new Waypoint from a given geographical point.
@@ -300,7 +298,7 @@ impl Waypoint {
     /// ```
     pub fn new(point: Point<f64>) -> Waypoint {
         Waypoint {
-            point: OurPoint { point },
+            point: GpxPoint(point),
             ..Default::default()
         }
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -171,12 +171,26 @@ impl ToGeo<f64> for TrackSegment {
     }
 }
 
+// A Version of geo::Point that has the Default trait implemented
+#[derive(Clone, Debug)]
+struct OurPoint {
+    point: Point<f64>,
+}
+
+impl Default for OurPoint {
+    fn default() -> OurPoint {
+        OurPoint {
+            point: Point::new(0 as f64, 0 as f64),
+        }
+    }
+}
+
 /// Waypoint represents a waypoint, point of interest, or named feature on a
 /// map.
-#[derive(Clone, Debug)]
+#[derive(Clone, Default, Debug)]
 pub struct Waypoint {
     /// The geographical point.
-    point: Point<f64>,
+    point: OurPoint,
 
     /// Elevation (in meters) of the point.
     pub elevation: Option<f64>,
@@ -265,7 +279,7 @@ impl Waypoint {
     /// }
     /// ```
     pub fn point(&self) -> Point<f64> {
-        self.point
+        self.point.point
     }
 
     /// Creates a new Waypoint from a given geographical point.
@@ -285,26 +299,9 @@ impl Waypoint {
     /// }
     /// ```
     pub fn new(point: Point<f64>) -> Waypoint {
-        // Unfortunately we don't have an easy way to write this.
         Waypoint {
-            point: point,
-            elevation: None,
-            speed: None,
-            time: None,
-            name: None,
-            comment: None,
-            description: None,
-            source: None,
-            links: vec![],
-            symbol: None,
-            _type: None,
-            fix: None,
-            sat: None,
-            hdop: None,
-            vdop: None,
-            pdop: None,
-            age: None,
-            dgpsid: None,
+            point: OurPoint { point },
+            ..Default::default()
         }
     }
 }


### PR DESCRIPTION
Reworked every parser file, with the exception of extensions.rs.

Changes and cleanup were mostly:
- Every parser is now responsible for consuming his own starting and closing tags (previously some
  parsers would be okay not having any starting tag, and would be used like this). To be able to achieve
  this any parser that calls further consume functions must use peek() to leave starting tags in the reader
  for the subparser to handle.
- Many parsers were accepting any amount of their starting tag, and also consuming any closing tag as
  valid, ignoring the name. Now exactly one opening tag and matching closing tag is required.
- Parsers that were already using peek() were doing so via a level of indirection through some form of
  "ParseEvent" enum, I think I have found a cleaner solution using .clone() on the event which allows us
  to remove this indirection and parse XmlEvents more directly even with peek().
- Added some more custom errors, and generally use custom errors more